### PR TITLE
feat(nginx): Add distroless nginx images (stable + mainline)

### DIFF
--- a/bazel/include/oci.MODULE.bazel
+++ b/bazel/include/oci.MODULE.bazel
@@ -28,7 +28,17 @@ apt.install(
     lock = "@@//distroless:debian13.lock.json",
     manifest = "//distroless:debian13.yaml",
 )
-use_repo(apt, "debian13")
+apt.install(
+    name = "nginx_stable",
+    lock = "@@//distroless:nginx-stable.lock.json",
+    manifest = "//distroless:nginx-stable.yaml",
+)
+apt.install(
+    name = "nginx_mainline",
+    lock = "@@//distroless:nginx-mainline.lock.json",
+    manifest = "//distroless:nginx-mainline.yaml",
+)
+use_repo(apt, "debian13", "nginx_stable", "nginx_mainline")
 
 grype_db = use_extension("@grype.bzl//grype:extensions.bzl", "grype_database")
 grype_db.database(

--- a/distroless/nginx-mainline.lock.json
+++ b/distroless/nginx-mainline.lock.json
@@ -1,0 +1,403 @@
+{
+	"packages": [
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "lsb-base_11.6_amd64",
+					"name": "lsb-base",
+					"version": "11.6"
+				},
+				{
+					"key": "sysvinit-utils_3.14-4_amd64",
+					"name": "sysvinit-utils",
+					"version": "3.14-4"
+				},
+				{
+					"key": "libc6_2.41-12-p-deb13u2_amd64",
+					"name": "libc6",
+					"version": "2.41-12+deb13u2"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-19_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-19"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-19_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-19"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-p-really1.3.1-1-p-b1_amd64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg+really1.3.1-1+b1"
+				},
+				{
+					"key": "libssl3t64_3.5.5-1_deb13u1_amd64",
+					"name": "libssl3t64",
+					"version": "3.5.5-1~deb13u1"
+				},
+				{
+					"key": "openssl-provider-legacy_3.5.5-1_deb13u1_amd64",
+					"name": "openssl-provider-legacy",
+					"version": "3.5.5-1~deb13u1"
+				},
+				{
+					"key": "libzstd1_1.5.7-p-dfsg-1_amd64",
+					"name": "libzstd1",
+					"version": "1.5.7+dfsg-1"
+				},
+				{
+					"key": "libpcre2-8-0_10.46-1_deb13u1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.46-1~deb13u1"
+				},
+				{
+					"key": "libcrypt1_1-4.4.38-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.38-1"
+				}
+			],
+			"key": "nginx_1.29.7-1_trixie_amd64",
+			"name": "nginx",
+			"sha256": "9452d13ec9c604f1a1c3ef5c417cd94a149a326d23c6e027f136471bddc06799",
+			"urls": [
+				"https://nginx.org/packages/mainline/debian/pool/nginx/n/nginx/nginx_1.29.7-1~trixie_amd64.deb"
+			],
+			"version": "1.29.7-1~trixie"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "lsb-base_11.6_amd64",
+			"name": "lsb-base",
+			"sha256": "f8bedd167280e76636df3a1bc023cd2906d458916c1af4c1d7912c5b971fc642",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/l/lsb/lsb-base_11.6_all.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/l/lsb/lsb-base_11.6_all.deb"
+			],
+			"version": "11.6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "sysvinit-utils_3.14-4_amd64",
+			"name": "sysvinit-utils",
+			"sha256": "c7e957360dff89675b491e501b00047cf750695178cabab167c92fc260d358ec",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/s/sysvinit/sysvinit-utils_3.14-4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/s/sysvinit/sysvinit-utils_3.14-4_amd64.deb"
+			],
+			"version": "3.14-4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libc6_2.41-12-p-deb13u2_amd64",
+			"name": "libc6",
+			"sha256": "8f9ddeb958cec3a05c4c303d4c85fddf30cb994747b16b1eb715ac49049f6d4a",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/g/glibc/libc6_2.41-12+deb13u2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/g/glibc/libc6_2.41-12+deb13u2_amd64.deb"
+			],
+			"version": "2.41-12+deb13u2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcc-s1_14.2.0-19_amd64",
+			"name": "libgcc-s1",
+			"sha256": "3c71917b490d1a17aed43196a2787a256ecf060526cdb20216a74bedc061b150",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/g/gcc-14/libgcc-s1_14.2.0-19_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/g/gcc-14/libgcc-s1_14.2.0-19_amd64.deb"
+			],
+			"version": "14.2.0-19"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gcc-14-base_14.2.0-19_amd64",
+			"name": "gcc-14-base",
+			"sha256": "5b6825de4263824b78c4c51f6476414f3b4e89c2ab63e81dc8b9b5501e867cf6",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/g/gcc-14/gcc-14-base_14.2.0-19_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/g/gcc-14/gcc-14-base_14.2.0-19_amd64.deb"
+			],
+			"version": "14.2.0-19"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "zlib1g_1-1.3.dfsg-p-really1.3.1-1-p-b1_amd64",
+			"name": "zlib1g",
+			"sha256": "015be740d6236ad114582dea500c1d907f29e16d6db00566ca32fb68d71ac90d",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1+b1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1+b1_amd64.deb"
+			],
+			"version": "1:1.3.dfsg+really1.3.1-1+b1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libssl3t64_3.5.5-1_deb13u1_amd64",
+			"name": "libssl3t64",
+			"sha256": "9a5d0bc0c5fcdd11e8d70bf01ab444a10aebae7d90ea6e25f93ddc797b134dbc",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/o/openssl/libssl3t64_3.5.5-1~deb13u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/o/openssl/libssl3t64_3.5.5-1~deb13u1_amd64.deb"
+			],
+			"version": "3.5.5-1~deb13u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "openssl-provider-legacy_3.5.5-1_deb13u1_amd64",
+			"name": "openssl-provider-legacy",
+			"sha256": "151dad4437b13720be5c0d6b313f0b451690ca2d697c76ebea28b9d3e390f727",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/o/openssl/openssl-provider-legacy_3.5.5-1~deb13u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/o/openssl/openssl-provider-legacy_3.5.5-1~deb13u1_amd64.deb"
+			],
+			"version": "3.5.5-1~deb13u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libzstd1_1.5.7-p-dfsg-1_amd64",
+			"name": "libzstd1",
+			"sha256": "2f6a2aeacfc925eba8b00ac9139bc4bfccf8cacb09eb93de067074b26948eef9",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/libz/libzstd/libzstd1_1.5.7+dfsg-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/libz/libzstd/libzstd1_1.5.7+dfsg-1_amd64.deb"
+			],
+			"version": "1.5.7+dfsg-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpcre2-8-0_10.46-1_deb13u1_amd64",
+			"name": "libpcre2-8-0",
+			"sha256": "6aa452af6a07e34498bf8e734e8789c9dd602fb34f12572e62dc1bba4889a60e",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/p/pcre2/libpcre2-8-0_10.46-1~deb13u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/p/pcre2/libpcre2-8-0_10.46-1~deb13u1_amd64.deb"
+			],
+			"version": "10.46-1~deb13u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcrypt1_1-4.4.38-1_amd64",
+			"name": "libcrypt1",
+			"sha256": "0ebc144d662e3197982d1bf3a7b8b35ca845e54c68811de0328b1f0d7c67585c",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/libx/libxcrypt/libcrypt1_4.4.38-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/libx/libxcrypt/libcrypt1_4.4.38-1_amd64.deb"
+			],
+			"version": "1:4.4.38-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "lsb-base_11.6_arm64",
+					"name": "lsb-base",
+					"version": "11.6"
+				},
+				{
+					"key": "sysvinit-utils_3.14-4_arm64",
+					"name": "sysvinit-utils",
+					"version": "3.14-4"
+				},
+				{
+					"key": "libc6_2.41-12-p-deb13u2_arm64",
+					"name": "libc6",
+					"version": "2.41-12+deb13u2"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-19_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-19"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-19_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-19"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-p-really1.3.1-1-p-b1_arm64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg+really1.3.1-1+b1"
+				},
+				{
+					"key": "libssl3t64_3.5.5-1_deb13u1_arm64",
+					"name": "libssl3t64",
+					"version": "3.5.5-1~deb13u1"
+				},
+				{
+					"key": "openssl-provider-legacy_3.5.5-1_deb13u1_arm64",
+					"name": "openssl-provider-legacy",
+					"version": "3.5.5-1~deb13u1"
+				},
+				{
+					"key": "libzstd1_1.5.7-p-dfsg-1_arm64",
+					"name": "libzstd1",
+					"version": "1.5.7+dfsg-1"
+				},
+				{
+					"key": "libpcre2-8-0_10.46-1_deb13u1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.46-1~deb13u1"
+				},
+				{
+					"key": "libcrypt1_1-4.4.38-1_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.38-1"
+				}
+			],
+			"key": "nginx_1.29.7-1_trixie_arm64",
+			"name": "nginx",
+			"sha256": "09cdd642ee07ad1cd9f4c8127231d0d1119194d66c458f888d8dd912d3d999ae",
+			"urls": [
+				"https://nginx.org/packages/mainline/debian/pool/nginx/n/nginx/nginx_1.29.7-1~trixie_arm64.deb"
+			],
+			"version": "1.29.7-1~trixie"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "lsb-base_11.6_arm64",
+			"name": "lsb-base",
+			"sha256": "f8bedd167280e76636df3a1bc023cd2906d458916c1af4c1d7912c5b971fc642",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/l/lsb/lsb-base_11.6_all.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/l/lsb/lsb-base_11.6_all.deb"
+			],
+			"version": "11.6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "sysvinit-utils_3.14-4_arm64",
+			"name": "sysvinit-utils",
+			"sha256": "1366e87a382a6b95a0a7c507b8f1be9b193f772f3428f9f7e0271a217915cfae",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/s/sysvinit/sysvinit-utils_3.14-4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/s/sysvinit/sysvinit-utils_3.14-4_arm64.deb"
+			],
+			"version": "3.14-4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libc6_2.41-12-p-deb13u2_arm64",
+			"name": "libc6",
+			"sha256": "f4679f22ee71be9f79bb36c62bb0b6fed97c19f245d2afaf8a9c1d000a1d312a",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/g/glibc/libc6_2.41-12+deb13u2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/g/glibc/libc6_2.41-12+deb13u2_arm64.deb"
+			],
+			"version": "2.41-12+deb13u2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgcc-s1_14.2.0-19_arm64",
+			"name": "libgcc-s1",
+			"sha256": "1108bc87879833d6d9a145f22a4a15cddb34e065b4b5f4b97bee586adbac2851",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/g/gcc-14/libgcc-s1_14.2.0-19_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/g/gcc-14/libgcc-s1_14.2.0-19_arm64.deb"
+			],
+			"version": "14.2.0-19"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "gcc-14-base_14.2.0-19_arm64",
+			"name": "gcc-14-base",
+			"sha256": "34ee90679b018c0e64234747a4c4c0ae6b7f63541115037465a8627c2dfbc594",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/g/gcc-14/gcc-14-base_14.2.0-19_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/g/gcc-14/gcc-14-base_14.2.0-19_arm64.deb"
+			],
+			"version": "14.2.0-19"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "zlib1g_1-1.3.dfsg-p-really1.3.1-1-p-b1_arm64",
+			"name": "zlib1g",
+			"sha256": "209aa5cf671e97b9eb0410844fa6df4cae2e75b0c72e7802ab6c8ece13e6ddef",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1+b1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1+b1_arm64.deb"
+			],
+			"version": "1:1.3.dfsg+really1.3.1-1+b1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libssl3t64_3.5.5-1_deb13u1_arm64",
+			"name": "libssl3t64",
+			"sha256": "7273dabe9471b474bcbceffd1caf7207e37fa7d7e4974cfb033c1ea2f6f3ef51",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/o/openssl/libssl3t64_3.5.5-1~deb13u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/o/openssl/libssl3t64_3.5.5-1~deb13u1_arm64.deb"
+			],
+			"version": "3.5.5-1~deb13u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "openssl-provider-legacy_3.5.5-1_deb13u1_arm64",
+			"name": "openssl-provider-legacy",
+			"sha256": "b33aa420fef82811f28dbdcefb55315857a0fda76328f7f1623d2a20cdeb69b7",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/o/openssl/openssl-provider-legacy_3.5.5-1~deb13u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/o/openssl/openssl-provider-legacy_3.5.5-1~deb13u1_arm64.deb"
+			],
+			"version": "3.5.5-1~deb13u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libzstd1_1.5.7-p-dfsg-1_arm64",
+			"name": "libzstd1",
+			"sha256": "924540bd59fdbfa77a0604360efdaca54411a43daf11c7e002a3c64791b67448",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/libz/libzstd/libzstd1_1.5.7+dfsg-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/libz/libzstd/libzstd1_1.5.7+dfsg-1_arm64.deb"
+			],
+			"version": "1.5.7+dfsg-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpcre2-8-0_10.46-1_deb13u1_arm64",
+			"name": "libpcre2-8-0",
+			"sha256": "f74d3e1082c2d6d2f7b4d47e41070de4a7e2f7f9d0e6e0c901ebfe0e82cdd3ee",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/p/pcre2/libpcre2-8-0_10.46-1~deb13u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/p/pcre2/libpcre2-8-0_10.46-1~deb13u1_arm64.deb"
+			],
+			"version": "10.46-1~deb13u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcrypt1_1-4.4.38-1_arm64",
+			"name": "libcrypt1",
+			"sha256": "b9aaa808aa3812b3de3e54eb5dfb16762c1779db032604abef2354c02fdc29b8",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/libx/libxcrypt/libcrypt1_4.4.38-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/libx/libxcrypt/libcrypt1_4.4.38-1_arm64.deb"
+			],
+			"version": "1:4.4.38-1"
+		}
+	],
+	"version": 1
+}

--- a/distroless/nginx-mainline.yaml
+++ b/distroless/nginx-mainline.yaml
@@ -1,0 +1,20 @@
+#  Anytime this file is changed, the lockfile needs to be regenerated.
+#
+#  To generate the nginx-mainline.lock.json run the following command
+#
+#     bazel run @nginx_mainline//:lock
+version: 1
+sources:
+  - channel: trixie nginx
+    url: https://nginx.org/packages/mainline/debian
+  - channel: trixie main
+    urls:
+      - https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z
+      - https://snapshot.debian.org/archive/debian/20260320T143128Z
+  - channel: trixie-security main
+    url: https://snapshot-cloudflare.debian.org/archive/debian-security/20260320T001422Z
+archs:
+  - amd64
+  - arm64
+packages:
+  - nginx

--- a/distroless/nginx-stable.lock.json
+++ b/distroless/nginx-stable.lock.json
@@ -1,0 +1,403 @@
+{
+	"packages": [
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "lsb-base_11.6_amd64",
+					"name": "lsb-base",
+					"version": "11.6"
+				},
+				{
+					"key": "sysvinit-utils_3.14-4_amd64",
+					"name": "sysvinit-utils",
+					"version": "3.14-4"
+				},
+				{
+					"key": "libc6_2.41-12-p-deb13u2_amd64",
+					"name": "libc6",
+					"version": "2.41-12+deb13u2"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-19_amd64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-19"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-19_amd64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-19"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-p-really1.3.1-1-p-b1_amd64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg+really1.3.1-1+b1"
+				},
+				{
+					"key": "libssl3t64_3.5.5-1_deb13u1_amd64",
+					"name": "libssl3t64",
+					"version": "3.5.5-1~deb13u1"
+				},
+				{
+					"key": "openssl-provider-legacy_3.5.5-1_deb13u1_amd64",
+					"name": "openssl-provider-legacy",
+					"version": "3.5.5-1~deb13u1"
+				},
+				{
+					"key": "libzstd1_1.5.7-p-dfsg-1_amd64",
+					"name": "libzstd1",
+					"version": "1.5.7+dfsg-1"
+				},
+				{
+					"key": "libpcre2-8-0_10.46-1_deb13u1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.46-1~deb13u1"
+				},
+				{
+					"key": "libcrypt1_1-4.4.38-1_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.38-1"
+				}
+			],
+			"key": "nginx_1.28.3-1_trixie_amd64",
+			"name": "nginx",
+			"sha256": "6a562adf5e1a5d1b54d58496d4eb95ee272c04548822736e620731511108a731",
+			"urls": [
+				"https://nginx.org/packages/debian/pool/nginx/n/nginx/nginx_1.28.3-1~trixie_amd64.deb"
+			],
+			"version": "1.28.3-1~trixie"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "lsb-base_11.6_amd64",
+			"name": "lsb-base",
+			"sha256": "f8bedd167280e76636df3a1bc023cd2906d458916c1af4c1d7912c5b971fc642",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/l/lsb/lsb-base_11.6_all.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/l/lsb/lsb-base_11.6_all.deb"
+			],
+			"version": "11.6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "sysvinit-utils_3.14-4_amd64",
+			"name": "sysvinit-utils",
+			"sha256": "c7e957360dff89675b491e501b00047cf750695178cabab167c92fc260d358ec",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/s/sysvinit/sysvinit-utils_3.14-4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/s/sysvinit/sysvinit-utils_3.14-4_amd64.deb"
+			],
+			"version": "3.14-4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libc6_2.41-12-p-deb13u2_amd64",
+			"name": "libc6",
+			"sha256": "8f9ddeb958cec3a05c4c303d4c85fddf30cb994747b16b1eb715ac49049f6d4a",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/g/glibc/libc6_2.41-12+deb13u2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/g/glibc/libc6_2.41-12+deb13u2_amd64.deb"
+			],
+			"version": "2.41-12+deb13u2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcc-s1_14.2.0-19_amd64",
+			"name": "libgcc-s1",
+			"sha256": "3c71917b490d1a17aed43196a2787a256ecf060526cdb20216a74bedc061b150",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/g/gcc-14/libgcc-s1_14.2.0-19_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/g/gcc-14/libgcc-s1_14.2.0-19_amd64.deb"
+			],
+			"version": "14.2.0-19"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gcc-14-base_14.2.0-19_amd64",
+			"name": "gcc-14-base",
+			"sha256": "5b6825de4263824b78c4c51f6476414f3b4e89c2ab63e81dc8b9b5501e867cf6",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/g/gcc-14/gcc-14-base_14.2.0-19_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/g/gcc-14/gcc-14-base_14.2.0-19_amd64.deb"
+			],
+			"version": "14.2.0-19"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "zlib1g_1-1.3.dfsg-p-really1.3.1-1-p-b1_amd64",
+			"name": "zlib1g",
+			"sha256": "015be740d6236ad114582dea500c1d907f29e16d6db00566ca32fb68d71ac90d",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1+b1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1+b1_amd64.deb"
+			],
+			"version": "1:1.3.dfsg+really1.3.1-1+b1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libssl3t64_3.5.5-1_deb13u1_amd64",
+			"name": "libssl3t64",
+			"sha256": "9a5d0bc0c5fcdd11e8d70bf01ab444a10aebae7d90ea6e25f93ddc797b134dbc",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/o/openssl/libssl3t64_3.5.5-1~deb13u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/o/openssl/libssl3t64_3.5.5-1~deb13u1_amd64.deb"
+			],
+			"version": "3.5.5-1~deb13u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "openssl-provider-legacy_3.5.5-1_deb13u1_amd64",
+			"name": "openssl-provider-legacy",
+			"sha256": "151dad4437b13720be5c0d6b313f0b451690ca2d697c76ebea28b9d3e390f727",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/o/openssl/openssl-provider-legacy_3.5.5-1~deb13u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/o/openssl/openssl-provider-legacy_3.5.5-1~deb13u1_amd64.deb"
+			],
+			"version": "3.5.5-1~deb13u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libzstd1_1.5.7-p-dfsg-1_amd64",
+			"name": "libzstd1",
+			"sha256": "2f6a2aeacfc925eba8b00ac9139bc4bfccf8cacb09eb93de067074b26948eef9",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/libz/libzstd/libzstd1_1.5.7+dfsg-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/libz/libzstd/libzstd1_1.5.7+dfsg-1_amd64.deb"
+			],
+			"version": "1.5.7+dfsg-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpcre2-8-0_10.46-1_deb13u1_amd64",
+			"name": "libpcre2-8-0",
+			"sha256": "6aa452af6a07e34498bf8e734e8789c9dd602fb34f12572e62dc1bba4889a60e",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/p/pcre2/libpcre2-8-0_10.46-1~deb13u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/p/pcre2/libpcre2-8-0_10.46-1~deb13u1_amd64.deb"
+			],
+			"version": "10.46-1~deb13u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcrypt1_1-4.4.38-1_amd64",
+			"name": "libcrypt1",
+			"sha256": "0ebc144d662e3197982d1bf3a7b8b35ca845e54c68811de0328b1f0d7c67585c",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/libx/libxcrypt/libcrypt1_4.4.38-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/libx/libxcrypt/libcrypt1_4.4.38-1_amd64.deb"
+			],
+			"version": "1:4.4.38-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "lsb-base_11.6_arm64",
+					"name": "lsb-base",
+					"version": "11.6"
+				},
+				{
+					"key": "sysvinit-utils_3.14-4_arm64",
+					"name": "sysvinit-utils",
+					"version": "3.14-4"
+				},
+				{
+					"key": "libc6_2.41-12-p-deb13u2_arm64",
+					"name": "libc6",
+					"version": "2.41-12+deb13u2"
+				},
+				{
+					"key": "libgcc-s1_14.2.0-19_arm64",
+					"name": "libgcc-s1",
+					"version": "14.2.0-19"
+				},
+				{
+					"key": "gcc-14-base_14.2.0-19_arm64",
+					"name": "gcc-14-base",
+					"version": "14.2.0-19"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-p-really1.3.1-1-p-b1_arm64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg+really1.3.1-1+b1"
+				},
+				{
+					"key": "libssl3t64_3.5.5-1_deb13u1_arm64",
+					"name": "libssl3t64",
+					"version": "3.5.5-1~deb13u1"
+				},
+				{
+					"key": "openssl-provider-legacy_3.5.5-1_deb13u1_arm64",
+					"name": "openssl-provider-legacy",
+					"version": "3.5.5-1~deb13u1"
+				},
+				{
+					"key": "libzstd1_1.5.7-p-dfsg-1_arm64",
+					"name": "libzstd1",
+					"version": "1.5.7+dfsg-1"
+				},
+				{
+					"key": "libpcre2-8-0_10.46-1_deb13u1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.46-1~deb13u1"
+				},
+				{
+					"key": "libcrypt1_1-4.4.38-1_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.38-1"
+				}
+			],
+			"key": "nginx_1.28.3-1_trixie_arm64",
+			"name": "nginx",
+			"sha256": "494d5e36c799725d773584d59cc16ae048d223d415e883d021158a03e6317046",
+			"urls": [
+				"https://nginx.org/packages/debian/pool/nginx/n/nginx/nginx_1.28.3-1~trixie_arm64.deb"
+			],
+			"version": "1.28.3-1~trixie"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "lsb-base_11.6_arm64",
+			"name": "lsb-base",
+			"sha256": "f8bedd167280e76636df3a1bc023cd2906d458916c1af4c1d7912c5b971fc642",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/l/lsb/lsb-base_11.6_all.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/l/lsb/lsb-base_11.6_all.deb"
+			],
+			"version": "11.6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "sysvinit-utils_3.14-4_arm64",
+			"name": "sysvinit-utils",
+			"sha256": "1366e87a382a6b95a0a7c507b8f1be9b193f772f3428f9f7e0271a217915cfae",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/s/sysvinit/sysvinit-utils_3.14-4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/s/sysvinit/sysvinit-utils_3.14-4_arm64.deb"
+			],
+			"version": "3.14-4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libc6_2.41-12-p-deb13u2_arm64",
+			"name": "libc6",
+			"sha256": "f4679f22ee71be9f79bb36c62bb0b6fed97c19f245d2afaf8a9c1d000a1d312a",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/g/glibc/libc6_2.41-12+deb13u2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/g/glibc/libc6_2.41-12+deb13u2_arm64.deb"
+			],
+			"version": "2.41-12+deb13u2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgcc-s1_14.2.0-19_arm64",
+			"name": "libgcc-s1",
+			"sha256": "1108bc87879833d6d9a145f22a4a15cddb34e065b4b5f4b97bee586adbac2851",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/g/gcc-14/libgcc-s1_14.2.0-19_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/g/gcc-14/libgcc-s1_14.2.0-19_arm64.deb"
+			],
+			"version": "14.2.0-19"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "gcc-14-base_14.2.0-19_arm64",
+			"name": "gcc-14-base",
+			"sha256": "34ee90679b018c0e64234747a4c4c0ae6b7f63541115037465a8627c2dfbc594",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/g/gcc-14/gcc-14-base_14.2.0-19_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/g/gcc-14/gcc-14-base_14.2.0-19_arm64.deb"
+			],
+			"version": "14.2.0-19"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "zlib1g_1-1.3.dfsg-p-really1.3.1-1-p-b1_arm64",
+			"name": "zlib1g",
+			"sha256": "209aa5cf671e97b9eb0410844fa6df4cae2e75b0c72e7802ab6c8ece13e6ddef",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1+b1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1+b1_arm64.deb"
+			],
+			"version": "1:1.3.dfsg+really1.3.1-1+b1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libssl3t64_3.5.5-1_deb13u1_arm64",
+			"name": "libssl3t64",
+			"sha256": "7273dabe9471b474bcbceffd1caf7207e37fa7d7e4974cfb033c1ea2f6f3ef51",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/o/openssl/libssl3t64_3.5.5-1~deb13u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/o/openssl/libssl3t64_3.5.5-1~deb13u1_arm64.deb"
+			],
+			"version": "3.5.5-1~deb13u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "openssl-provider-legacy_3.5.5-1_deb13u1_arm64",
+			"name": "openssl-provider-legacy",
+			"sha256": "b33aa420fef82811f28dbdcefb55315857a0fda76328f7f1623d2a20cdeb69b7",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/o/openssl/openssl-provider-legacy_3.5.5-1~deb13u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/o/openssl/openssl-provider-legacy_3.5.5-1~deb13u1_arm64.deb"
+			],
+			"version": "3.5.5-1~deb13u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libzstd1_1.5.7-p-dfsg-1_arm64",
+			"name": "libzstd1",
+			"sha256": "924540bd59fdbfa77a0604360efdaca54411a43daf11c7e002a3c64791b67448",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/libz/libzstd/libzstd1_1.5.7+dfsg-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/libz/libzstd/libzstd1_1.5.7+dfsg-1_arm64.deb"
+			],
+			"version": "1.5.7+dfsg-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpcre2-8-0_10.46-1_deb13u1_arm64",
+			"name": "libpcre2-8-0",
+			"sha256": "f74d3e1082c2d6d2f7b4d47e41070de4a7e2f7f9d0e6e0c901ebfe0e82cdd3ee",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/p/pcre2/libpcre2-8-0_10.46-1~deb13u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/p/pcre2/libpcre2-8-0_10.46-1~deb13u1_arm64.deb"
+			],
+			"version": "10.46-1~deb13u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcrypt1_1-4.4.38-1_arm64",
+			"name": "libcrypt1",
+			"sha256": "b9aaa808aa3812b3de3e54eb5dfb16762c1779db032604abef2354c02fdc29b8",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z/pool/main/libx/libxcrypt/libcrypt1_4.4.38-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20260320T143128Z/pool/main/libx/libxcrypt/libcrypt1_4.4.38-1_arm64.deb"
+			],
+			"version": "1:4.4.38-1"
+		}
+	],
+	"version": 1
+}

--- a/distroless/nginx-stable.yaml
+++ b/distroless/nginx-stable.yaml
@@ -1,0 +1,20 @@
+#  Anytime this file is changed, the lockfile needs to be regenerated.
+#
+#  To generate the nginx-stable.lock.json run the following command
+#
+#     bazel run @nginx_stable//:lock
+version: 1
+sources:
+  - channel: trixie nginx
+    url: https://nginx.org/packages/debian
+  - channel: trixie main
+    urls:
+      - https://snapshot-cloudflare.debian.org/archive/debian/20260320T143128Z
+      - https://snapshot.debian.org/archive/debian/20260320T143128Z
+  - channel: trixie-security main
+    url: https://snapshot-cloudflare.debian.org/archive/debian-security/20260320T001422Z
+archs:
+  - amd64
+  - arm64
+packages:
+  - nginx

--- a/distroless/nginx/BUILD
+++ b/distroless/nginx/BUILD
@@ -1,0 +1,123 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("@rules_distroless//distroless:defs.bzl", "flatten")
+load("@rules_img//img:push.bzl", "image_push")
+load("@tar.bzl", "tar")
+load("//distroless/common:variables.bzl", "DEBUG_MODE")
+load("//oci:config.bzl", "OCI_REGISTRY", "OCI_REPOSITORY_PREFIX")
+load(":config.bzl", "NGINX_ARCHITECTURES", "NGINX_DISTROS", "NGINX_TAGS", "NGINX_VERSIONS")
+load(":nginx.bzl", "nginx_image", "nginx_image_index")
+
+# CVE-2022-4899: libzstd, disputed - fixed in 2022 (https://github.com/facebook/zstd/issues/3200)
+# CVE-2026-1642: nginx stable, fix only in mainline 1.29.5+
+NGINX_IGNORE_CVES = [
+    "CVE-2022-4899",
+    "CVE-2026-1642",
+]
+
+package(default_visibility = ["//visibility:public"])
+
+tar(
+    name = "nginx_conf_layer",
+    srcs = [
+        "default.conf",
+        "nginx.conf",
+    ],
+    mtree = [
+        "./etc/nginx/nginx.conf uid=0 gid=0 mode=0644 type=file content=distroless/nginx/nginx.conf",
+        "./etc/nginx/conf.d type=dir uid=0 gid=0 mode=0755",
+        "./etc/nginx/conf.d/default.conf uid=0 gid=0 mode=0644 type=file content=distroless/nginx/default.conf",
+        "./var/www/html type=dir uid=0 gid=0 mode=0755",
+    ],
+)
+
+[
+    flatten(
+        name = version_label + "_" + arch + "_" + distro + "_layer",
+        deduplicate = True,
+        tars = [
+            "@{}//{}/{}".format(apt_repo, "nginx", arch),
+        ],
+    )
+    for version_label, apt_repo in NGINX_VERSIONS.items()
+    for distro in NGINX_DISTROS
+    for arch in NGINX_ARCHITECTURES[distro]
+]
+
+[
+    nginx_image(
+        name = "nginx",
+        arch = arch,
+        distro = distro,
+        ignore_cves = NGINX_IGNORE_CVES,
+        version_label = version_label,
+    )
+    for version_label in NGINX_VERSIONS
+    for distro in NGINX_DISTROS
+    for arch in NGINX_ARCHITECTURES[distro]
+]
+
+[
+    nginx_image_index(
+        name = "nginx",
+        architectures = NGINX_ARCHITECTURES[distro],
+        distro = distro,
+        version_label = version_label,
+    )
+    for version_label in NGINX_VERSIONS
+    for distro in NGINX_DISTROS
+]
+
+[
+    image_push(
+        name = "nginx_" + version_label + mode + "_push",
+        image = ":nginx_" + version_label + mode + "_nonroot_debian13",
+        registry = OCI_REGISTRY,
+        repository = OCI_REPOSITORY_PREFIX + "/nginx",
+        stamp = "enabled",
+        tag_list = [
+            version_label + ("-debug" if mode else ""),
+            short_version + ("-debug" if mode else ""),
+        ] + ([
+            "debug" if mode else "latest",
+        ] if version_label == "mainline" else []),
+        tags = ["manual"],
+    )
+    for version_label, short_version in NGINX_TAGS.items()
+    for mode in DEBUG_MODE
+]
+
+container_structure_test(
+    name = "nginx_stable_test",
+    size = "small",
+    configs = ["test.yaml"],
+    driver = "docker",
+    image = ":nginx_stable_nonroot_amd64_debian13.oci_layout",
+    tags = ["requires-docker"],
+)
+
+container_structure_test(
+    name = "nginx_mainline_test",
+    size = "small",
+    configs = ["test.yaml"],
+    driver = "docker",
+    image = ":nginx_mainline_nonroot_amd64_debian13.oci_layout",
+    tags = ["requires-docker"],
+)
+
+bzl_library(
+    name = "nginx",
+    srcs = ["nginx.bzl"],
+    deps = [
+        "//distroless:distro",
+        "//distroless/common:variables",
+        "//oci",
+        "@container_structure_test//:defs",
+        "@rules_img//img:image",
+    ],
+)
+
+bzl_library(
+    name = "config",
+    srcs = ["config.bzl"],
+)

--- a/distroless/nginx/BUILD
+++ b/distroless/nginx/BUILD
@@ -118,6 +118,18 @@ bzl_library(
 )
 
 bzl_library(
+    name = "frontend",
+    srcs = ["frontend.bzl"],
+    deps = [
+        ":config",
+        "//distroless:distro",
+        "//distroless/common:variables",
+        "//oci",
+        "@rules_img//img:image",
+    ],
+)
+
+bzl_library(
     name = "config",
     srcs = ["config.bzl"],
 )

--- a/distroless/nginx/BUILD
+++ b/distroless/nginx/BUILD
@@ -9,11 +9,16 @@ load(":config.bzl", "NGINX_ARCHITECTURES", "NGINX_DISTROS", "NGINX_TAGS", "NGINX
 load(":nginx.bzl", "nginx_image", "nginx_image_index")
 
 # CVE-2022-4899: libzstd, disputed - fixed in 2022 (https://github.com/facebook/zstd/issues/3200)
-# CVE-2026-1642: nginx stable, fix only in mainline 1.29.5+
-NGINX_IGNORE_CVES = [
-    "CVE-2022-4899",
-    "CVE-2026-1642",
-]
+# CVE-2026-1642: nginx stable only, fix in mainline 1.29.5+
+NGINX_IGNORE_CVES = {
+    "stable": [
+        "CVE-2022-4899",
+        "CVE-2026-1642",
+    ],
+    "mainline": [
+        "CVE-2022-4899",
+    ],
+}
 
 package(default_visibility = ["//visibility:public"])
 
@@ -49,7 +54,7 @@ tar(
         name = "nginx",
         arch = arch,
         distro = distro,
-        ignore_cves = NGINX_IGNORE_CVES,
+        ignore_cves = NGINX_IGNORE_CVES[version_label],
         version_label = version_label,
     )
     for version_label in NGINX_VERSIONS

--- a/distroless/nginx/BUILD
+++ b/distroless/nginx/BUILD
@@ -9,7 +9,7 @@ load(":config.bzl", "NGINX_ARCHITECTURES", "NGINX_DISTROS", "NGINX_TAGS", "NGINX
 load(":nginx.bzl", "nginx_image", "nginx_image_index")
 
 # CVE-2022-4899: libzstd, disputed - fixed in 2022 (https://github.com/facebook/zstd/issues/3200)
-# CVE-2026-1642: nginx stable only, fix in mainline 1.29.5+
+# CVE-2026-1642: nginx HTTP/2 HEADERS frame DoS, stable only - fixed in mainline 1.29.5+ (https://nvd.nist.gov/vuln/detail/CVE-2026-1642)
 NGINX_IGNORE_CVES = {
     "stable": [
         "CVE-2022-4899",

--- a/distroless/nginx/README.md
+++ b/distroless/nginx/README.md
@@ -45,31 +45,47 @@ docker run --rm -p 8080:8080 \
 
 ## Frontend Images
 
-Use the `frontend_image` macro to build images for static frontends (SPAs, static sites):
+Use the macros in `frontend.bzl` to build images for static frontends (SPAs, static sites).
+Static files are placed in `/var/www/html` on top of the nginx mainline nonroot base.
+
+### Multi-arch (recommended)
+
+```starlark
+load("//distroless/nginx:frontend.bzl", "frontend_images_all_arch")
+
+frontend_images_all_arch(
+    name = "my_app",
+    srcs = [":build"],
+)
+```
+
+Creates `my_app_amd64`, `my_app_arm64`, and `my_app` (multi-arch index).
+
+### Single-arch
 
 ```starlark
 load("//distroless/nginx:frontend.bzl", "frontend_image")
 
 frontend_image(
     name = "my_app",
-    srcs = [":build"],  # your built frontend assets
+    srcs = [":build"],
+    arch = "amd64",
 )
 ```
 
-This creates multi-arch images with your static files served from `/var/www/html`. Available targets:
+Creates `my_app_amd64`.
 
-- `my_app_nonroot` / `my_app_root` - multi-arch index
-- `my_app_nonroot_amd64` / `my_app_nonroot_arm64` - per-arch images
-- `my_app_debug_nonroot` - debug variants with shell
+### Options
 
-Options:
-
-| Parameter       | Default      | Description                              |
-|-----------------|--------------|------------------------------------------|
-| `srcs`          | required     | Static files to serve                    |
-| `strip_prefix`  | package name | Prefix to strip from file paths          |
-| `version_label` | `"mainline"` | Nginx channel: `"mainline"` or `"stable"` |
-| `ignore_cves`   | `None`       | CVE IDs to ignore in scanning            |
+| Parameter       | Default           | Description                              |
+|-----------------|-------------------|------------------------------------------|
+| `srcs`          | —                 | Static files to serve                    |
+| `statics_layer` | —                 | Pre-built tar layer (alternative to srcs)|
+| `base`          | mainline nonroot  | Custom base image (dict for all_arch)    |
+| `owner`         | `"65532"`         | UID for static files                     |
+| `ownername`     | `"nonroot"`       | Username for static files                |
+| `strip_prefix`  | package name      | Prefix to strip from file paths          |
+| `ignore_cves`   | `None`            | CVE IDs to ignore in scanning            |
 
 ## Variants
 

--- a/distroless/nginx/README.md
+++ b/distroless/nginx/README.md
@@ -43,6 +43,34 @@ docker run --rm -p 8080:8080 \
   bazel/distroless/nginx:nginx-mainline-nonroot-arm64-debian13
 ```
 
+## Frontend Images
+
+Use the `frontend_image` macro to build images for static frontends (SPAs, static sites):
+
+```starlark
+load("//distroless/nginx:frontend.bzl", "frontend_image")
+
+frontend_image(
+    name = "my_app",
+    srcs = [":build"],  # your built frontend assets
+)
+```
+
+This creates multi-arch images with your static files served from `/var/www/html`. Available targets:
+
+- `my_app_nonroot` / `my_app_root` - multi-arch index
+- `my_app_nonroot_amd64` / `my_app_nonroot_arm64` - per-arch images
+- `my_app_debug_nonroot` - debug variants with shell
+
+Options:
+
+| Parameter       | Default      | Description                              |
+|-----------------|--------------|------------------------------------------|
+| `srcs`          | required     | Static files to serve                    |
+| `strip_prefix`  | package name | Prefix to strip from file paths          |
+| `version_label` | `"mainline"` | Nginx channel: `"mainline"` or `"stable"` |
+| `ignore_cves`   | `None`       | CVE IDs to ignore in scanning            |
+
 ## Variants
 
 Each channel produces images for:

--- a/distroless/nginx/README.md
+++ b/distroless/nginx/README.md
@@ -1,0 +1,67 @@
+# Distroless Nginx
+
+Minimal nginx container images based on Debian Trixie (13), built from official [nginx.org](https://nginx.org/en/linux_packages.html#Debian) packages.
+
+Images are published to [GitHub Container Registry](https://github.com/arkeros/senku/pkgs/container/senku%2Fnginx/).
+
+```bash
+docker pull ghcr.io/arkeros/senku/nginx:latest
+```
+
+## Channels
+
+| Channel  | Version | Tags                         |
+|----------|---------|------------------------------|
+| Mainline | 1.29.x  | `latest`, `mainline`, `1.29` |
+| Stable   | 1.28.x  | `stable`, `1.28`             |
+
+## Usage
+
+```bash
+# Load into Docker
+bazel run //distroless/nginx:nginx_mainline_nonroot_arm64_debian13_load
+
+# Run
+docker run --rm -p 8080:8080 bazel/distroless/nginx:nginx-mainline-nonroot-arm64-debian13
+```
+
+The default configuration listens on port **8080** and serves from `/var/www/html`.
+
+## Configuration
+
+The image ships with a nonroot-friendly nginx config:
+
+- **`/etc/nginx/nginx.conf`** - Main config (pid/temp in `/tmp`, logs to stdout/stderr, `server_tokens off`)
+- **`/etc/nginx/conf.d/default.conf`** - Default server block (port 8080, SPA-friendly `try_files`)
+
+Override by mounting your own config:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -v ./my-site:/var/www/html:ro \
+  -v ./my.conf:/etc/nginx/conf.d/default.conf:ro \
+  bazel/distroless/nginx:nginx-mainline-nonroot-arm64-debian13
+```
+
+## Variants
+
+Each channel produces images for:
+
+- **Users**: `root`, `nonroot` (UID 65532)
+- **Architectures**: `amd64`, `arm64`
+- **Debug**: includes busybox shell
+
+Target naming: `nginx_{mainline,stable}[_debug]_{root,nonroot}_{amd64,arm64}_debian13`
+
+## Updating
+
+The nginx.org repo is not a Debian snapshot, so the lock file resolver picks the oldest version. After regenerating lock files, manually update the nginx entries to the latest version:
+
+```bash
+# Regenerate (will resolve to oldest version)
+bazel run @nginx_stable//:lock
+bazel run @nginx_mainline//:lock
+
+# Then update the nginx package entries in the lock files
+# to point to the latest version with correct SHA256
+```

--- a/distroless/nginx/README.md
+++ b/distroless/nginx/README.md
@@ -85,7 +85,7 @@ Creates `my_app_amd64`.
 | `owner`         | `"65532"`         | UID for static files                     |
 | `ownername`     | `"nonroot"`       | Username for static files                |
 | `strip_prefix`  | package name      | Prefix to strip from file paths          |
-| `ignore_cves`   | `None`            | CVE IDs to ignore in scanning            |
+| `**kwargs`      | —                 | Passed to `oci_image` (e.g., `ignore_cves`, `env`) |
 
 ## Variants
 

--- a/distroless/nginx/config.bzl
+++ b/distroless/nginx/config.bzl
@@ -1,0 +1,16 @@
+NGINX_VERSIONS = {
+    "stable": "nginx_stable",
+    "mainline": "nginx_mainline",
+}
+
+# version_label -> short_version tag
+NGINX_TAGS = {
+    "stable": "1.28",
+    "mainline": "1.29",
+}
+
+NGINX_DISTROS = ["debian13"]
+
+NGINX_ARCHITECTURES = {
+    "debian13": ["amd64", "arm64"],
+}

--- a/distroless/nginx/default.conf
+++ b/distroless/nginx/default.conf
@@ -3,10 +3,7 @@ server {
     root /var/www/html;
     index index.html index.htm;
 
-    client_max_body_size 2048M;
-
     location / {
-        alias /var/www/html/;
         try_files $uri $uri/ /index.html;
     }
 }

--- a/distroless/nginx/default.conf
+++ b/distroless/nginx/default.conf
@@ -1,0 +1,12 @@
+server {
+    listen 8080;
+    root /var/www/html;
+    index index.html index.htm;
+
+    client_max_body_size 2048M;
+
+    location / {
+        alias /var/www/html/;
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/distroless/nginx/frontend.bzl
+++ b/distroless/nginx/frontend.bzl
@@ -5,28 +5,55 @@ load("//distroless/common:variables.bzl", "NONROOT")
 load("//oci:oci.bzl", "oci_image")
 load(":config.bzl", "NGINX_ARCHITECTURES")
 
+def frontend_image_index(name, architectures):
+    """frontend image index
+
+    Args:
+        name: base name of image
+        architectures: all architectures included in index
+    """
+    image_index(
+        name = name,
+        manifests = [
+            name + "_" + arch
+            for arch in architectures
+        ],
+    )
+
 def frontend_image(
+        name,
+        distro,
+        arch,
+        statics_layer,
+        base = None,
+        ignore_cves = None):
+    oci_image(
+        name = name + "_" + arch,
+        base = base or "//distroless/nginx:nginx_mainline_nonroot_" + arch + "_" + distro,
+        layers = [statics_layer],
+        platform = ARCHITECTURE_PLATFORMS[arch],
+        ignore_cves = ignore_cves,
+    )
+
+def frontend_images_all_arch(
         name,
         srcs,
         base = None,
-        architectures = None,
         owner = str(NONROOT),
         ownername = "nonroot",
         strip_prefix = None,
         distro = "debian13",
         ignore_cves = None,
         visibility = None):
-    """Build frontend image(s) serving static files with nginx.
+    """Build frontend images for all architectures serving static files with nginx.
 
     Static files are placed in /var/www/html on top of the nginx base image.
-    When multiple architectures are specified, a multi-arch index is also created.
 
     Args:
         name: target name
         srcs: static files to serve (e.g., a filegroup of built frontend assets)
         base: base image per arch, as a dict {"amd64": "//my:image_amd64", ...}.
             Defaults to nginx mainline nonroot.
-        architectures: list of architectures to build for (default: all from distro config)
         owner: uid for static files (default: 65532/nonroot)
         ownername: uname for static files (default: nonroot)
         strip_prefix: prefix to strip from file paths before placing in /var/www/html.
@@ -35,7 +62,7 @@ def frontend_image(
         ignore_cves: list of CVE IDs to ignore in scanning
         visibility: target visibility
     """
-    architectures = architectures or NGINX_ARCHITECTURES[distro]
+    architectures = NGINX_ARCHITECTURES[distro]
 
     tar(
         name = name + "_statics_layer",
@@ -46,23 +73,22 @@ def frontend_image(
             package_dir = "/var/www/html",
             strip_prefix = strip_prefix or native.package_name(),
         ),
+        visibility = visibility,
     )
 
     [
-        oci_image(
-            name = name + "_" + arch,
-            base = base[arch] if base else "//distroless/nginx:nginx_mainline_nonroot_" + arch + "_" + distro,
-            layers = [name + "_statics_layer"],
-            platform = ARCHITECTURE_PLATFORMS[arch],
+        frontend_image(
+            name = name,
+            distro = distro,
+            arch = arch,
+            statics_layer = name + "_statics_layer",
+            base = base.get(arch) if base else None,
             ignore_cves = ignore_cves,
-            visibility = visibility,
         )
         for arch in architectures
     ]
 
-    if len(architectures) > 1:
-        image_index(
-            name = name,
-            manifests = [name + "_" + arch for arch in architectures],
-            visibility = visibility,
-        )
+    frontend_image_index(
+        name = name,
+        architectures = architectures,
+    )

--- a/distroless/nginx/frontend.bzl
+++ b/distroless/nginx/frontend.bzl
@@ -20,13 +20,54 @@ def frontend_image_index(name, architectures):
         ],
     )
 
+def _statics_layer(name, srcs, owner, ownername, strip_prefix):
+    tar(
+        name = name + "_statics_layer",
+        srcs = srcs,
+        mutate = mutate(
+            owner = owner,
+            ownername = ownername,
+            package_dir = "/var/www/html",
+            strip_prefix = strip_prefix or native.package_name(),
+        ),
+    )
+    return name + "_statics_layer"
+
 def frontend_image(
         name,
-        distro,
         arch,
-        statics_layer,
+        distro = "debian13",
+        srcs = None,
+        statics_layer = None,
         base = None,
+        owner = str(NONROOT),
+        ownername = "nonroot",
+        strip_prefix = None,
         ignore_cves = None):
+    """Build a single-arch frontend image serving static files with nginx.
+
+    Provide either srcs (static files) or statics_layer (pre-built tar layer).
+
+    Args:
+        name: target name
+        arch: target architecture (e.g., "amd64")
+        distro: distribution to use (default: debian13)
+        srcs: static files to serve
+        statics_layer: pre-built tar layer (mutually exclusive with srcs)
+        base: base image. Defaults to nginx mainline nonroot.
+        owner: uid for static files (default: 65532/nonroot), only used with srcs
+        ownername: uname for static files (default: nonroot), only used with srcs
+        strip_prefix: prefix to strip from file paths, only used with srcs
+        ignore_cves: list of CVE IDs to ignore in scanning
+    """
+    if srcs and statics_layer:
+        fail("srcs and statics_layer are mutually exclusive")
+    if not srcs and not statics_layer:
+        fail("one of srcs or statics_layer is required")
+
+    if srcs:
+        statics_layer = _statics_layer(name, srcs, owner, ownername, strip_prefix)
+
     oci_image(
         name = name + "_" + arch,
         base = base or "//distroless/nginx:nginx_mainline_nonroot_" + arch + "_" + distro,
@@ -64,24 +105,14 @@ def frontend_images_all_arch(
     """
     architectures = NGINX_ARCHITECTURES[distro]
 
-    tar(
-        name = name + "_statics_layer",
-        srcs = srcs,
-        mutate = mutate(
-            owner = owner,
-            ownername = ownername,
-            package_dir = "/var/www/html",
-            strip_prefix = strip_prefix or native.package_name(),
-        ),
-        visibility = visibility,
-    )
+    layer = _statics_layer(name, srcs, owner, ownername, strip_prefix)
 
     [
         frontend_image(
             name = name,
             distro = distro,
             arch = arch,
-            statics_layer = name + "_statics_layer",
+            statics_layer = layer,
             base = base.get(arch) if base else None,
             ignore_cves = ignore_cves,
         )

--- a/distroless/nginx/frontend.bzl
+++ b/distroless/nginx/frontend.bzl
@@ -76,15 +76,7 @@ def frontend_image(
         ignore_cves = ignore_cves,
     )
 
-def frontend_images_all_arch(
-        name,
-        srcs,
-        base = None,
-        owner = str(NONROOT),
-        ownername = "nonroot",
-        strip_prefix = None,
-        distro = "debian13",
-        ignore_cves = None):
+def frontend_images_all_arch(name, srcs, base = None, distro = "debian13", **kwargs):
     """Build frontend images for all architectures serving static files with nginx.
 
     Static files are placed in /var/www/html on top of the nginx base image.
@@ -94,16 +86,18 @@ def frontend_images_all_arch(
         srcs: static files to serve (e.g., a filegroup of built frontend assets)
         base: base image per arch, as a dict {"amd64": "//my:image_amd64", ...}.
             Defaults to nginx mainline nonroot.
-        owner: uid for static files (default: 65532/nonroot)
-        ownername: uname for static files (default: nonroot)
-        strip_prefix: prefix to strip from file paths before placing in /var/www/html.
-            Defaults to the current package name.
         distro: distribution to use (default: debian13)
-        ignore_cves: list of CVE IDs to ignore in scanning
+        **kwargs: passed to frontend_image (owner, ownername, strip_prefix, ignore_cves)
     """
     architectures = NGINX_ARCHITECTURES[distro]
 
-    layer = _statics_layer(name, srcs, owner, ownername, strip_prefix)
+    layer = _statics_layer(
+        name,
+        srcs,
+        kwargs.pop("owner", str(NONROOT)),
+        kwargs.pop("ownername", "nonroot"),
+        kwargs.pop("strip_prefix", None),
+    )
 
     [
         frontend_image(
@@ -112,7 +106,7 @@ def frontend_images_all_arch(
             arch = arch,
             statics_layer = layer,
             base = base.get(arch) if base else None,
-            ignore_cves = ignore_cves,
+            **kwargs
         )
         for arch in architectures
     ]

--- a/distroless/nginx/frontend.bzl
+++ b/distroless/nginx/frontend.bzl
@@ -84,8 +84,7 @@ def frontend_images_all_arch(
         ownername = "nonroot",
         strip_prefix = None,
         distro = "debian13",
-        ignore_cves = None,
-        visibility = None):
+        ignore_cves = None):
     """Build frontend images for all architectures serving static files with nginx.
 
     Static files are placed in /var/www/html on top of the nginx base image.
@@ -101,7 +100,6 @@ def frontend_images_all_arch(
             Defaults to the current package name.
         distro: distribution to use (default: debian13)
         ignore_cves: list of CVE IDs to ignore in scanning
-        visibility: target visibility
     """
     architectures = NGINX_ARCHITECTURES[distro]
 

--- a/distroless/nginx/frontend.bzl
+++ b/distroless/nginx/frontend.bzl
@@ -89,6 +89,9 @@ def frontend_images_all_arch(name, srcs, base = None, distro = "debian13", **kwa
         distro: distribution to use (default: debian13)
         **kwargs: passed to frontend_image (owner, ownername, strip_prefix, ignore_cves)
     """
+    if distro not in NGINX_ARCHITECTURES:
+        fail("unknown distro %r, expected one of: %s" % (distro, ", ".join(NGINX_ARCHITECTURES.keys())))
+
     architectures = NGINX_ARCHITECTURES[distro]
 
     layer = _statics_layer(

--- a/distroless/nginx/frontend.bzl
+++ b/distroless/nginx/frontend.bzl
@@ -60,6 +60,8 @@ def frontend_image(
         strip_prefix: prefix to strip from file paths, only used with srcs
         **kwargs: passed to oci_image (ignore_cves, env, etc.)
     """
+    if distro not in NGINX_ARCHITECTURES:
+        fail("unknown distro %r, expected one of: %s" % (distro, ", ".join(NGINX_ARCHITECTURES.keys())))
     if srcs and statics_layer:
         fail("srcs and statics_layer are mutually exclusive")
     if not srcs and not statics_layer:
@@ -89,9 +91,6 @@ def frontend_images_all_arch(name, srcs, base = None, distro = "debian13", **kwa
         distro: distribution to use (default: debian13)
         **kwargs: passed to frontend_image (owner, ownername, strip_prefix, ignore_cves)
     """
-    if distro not in NGINX_ARCHITECTURES:
-        fail("unknown distro %r, expected one of: %s" % (distro, ", ".join(NGINX_ARCHITECTURES.keys())))
-
     architectures = NGINX_ARCHITECTURES[distro]
 
     layer = _statics_layer(

--- a/distroless/nginx/frontend.bzl
+++ b/distroless/nginx/frontend.bzl
@@ -8,18 +8,20 @@ load(":config.bzl", "NGINX_ARCHITECTURES")
 def frontend_image(
         name,
         srcs,
+        base = None,
         strip_prefix = None,
         distro = "debian13",
         ignore_cves = None,
         visibility = None):
     """Build a multi-arch frontend image serving static files with nginx.
 
-    Static files are placed in /var/www/html on top of the nginx mainline
-    nonroot base image.
+    Static files are placed in /var/www/html on top of the nginx base image.
 
     Args:
         name: target name
         srcs: static files to serve (e.g., a filegroup of built frontend assets)
+        base: base image per arch, as a dict {"amd64": "//my:image_amd64", ...}.
+            Defaults to nginx mainline nonroot.
         strip_prefix: prefix to strip from file paths before placing in /var/www/html.
             Defaults to the current package name.
         distro: distribution to use (default: debian13)
@@ -27,6 +29,11 @@ def frontend_image(
         visibility: target visibility
     """
     architectures = NGINX_ARCHITECTURES[distro]
+    if not base:
+        base = {
+            arch: "//distroless/nginx:nginx_mainline_nonroot_" + arch + "_" + distro
+            for arch in architectures
+        }
 
     tar(
         name = name + "_statics_layer",
@@ -42,7 +49,7 @@ def frontend_image(
     [
         oci_image(
             name = name + "_" + arch,
-            base = "//distroless/nginx:nginx_mainline_nonroot_" + arch + "_" + distro,
+            base = base[arch],
             layers = [name + "_statics_layer"],
             platform = ARCHITECTURE_PLATFORMS[arch],
             ignore_cves = ignore_cves,

--- a/distroless/nginx/frontend.bzl
+++ b/distroless/nginx/frontend.bzl
@@ -1,0 +1,58 @@
+load("@rules_img//img:image.bzl", "image_index")
+load("@tar.bzl", "mutate", "tar")
+load("//distroless:distro.bzl", "ARCHITECTURE_PLATFORMS")
+load("//distroless/common:variables.bzl", "NONROOT")
+load("//oci:oci.bzl", "oci_image")
+load(":config.bzl", "NGINX_ARCHITECTURES")
+
+def frontend_image(
+        name,
+        srcs,
+        strip_prefix = None,
+        distro = "debian13",
+        ignore_cves = None,
+        visibility = None):
+    """Build a multi-arch frontend image serving static files with nginx.
+
+    Static files are placed in /var/www/html on top of the nginx mainline
+    nonroot base image.
+
+    Args:
+        name: target name
+        srcs: static files to serve (e.g., a filegroup of built frontend assets)
+        strip_prefix: prefix to strip from file paths before placing in /var/www/html.
+            Defaults to the current package name.
+        distro: distribution to use (default: debian13)
+        ignore_cves: list of CVE IDs to ignore in scanning
+        visibility: target visibility
+    """
+    architectures = NGINX_ARCHITECTURES[distro]
+
+    tar(
+        name = name + "_statics_layer",
+        srcs = srcs,
+        mutate = mutate(
+            owner = str(NONROOT),
+            ownername = "nonroot",
+            package_dir = "/var/www/html",
+            strip_prefix = strip_prefix or native.package_name(),
+        ),
+    )
+
+    [
+        oci_image(
+            name = name + "_" + arch,
+            base = "//distroless/nginx:nginx_mainline_nonroot_" + arch + "_" + distro,
+            layers = [name + "_statics_layer"],
+            platform = ARCHITECTURE_PLATFORMS[arch],
+            ignore_cves = ignore_cves,
+            visibility = visibility,
+        )
+        for arch in architectures
+    ]
+
+    image_index(
+        name = name,
+        manifests = [name + "_" + arch for arch in architectures],
+        visibility = visibility,
+    )

--- a/distroless/nginx/frontend.bzl
+++ b/distroless/nginx/frontend.bzl
@@ -9,38 +9,40 @@ def frontend_image(
         name,
         srcs,
         base = None,
+        architectures = None,
+        owner = str(NONROOT),
+        ownername = "nonroot",
         strip_prefix = None,
         distro = "debian13",
         ignore_cves = None,
         visibility = None):
-    """Build a multi-arch frontend image serving static files with nginx.
+    """Build frontend image(s) serving static files with nginx.
 
     Static files are placed in /var/www/html on top of the nginx base image.
+    When multiple architectures are specified, a multi-arch index is also created.
 
     Args:
         name: target name
         srcs: static files to serve (e.g., a filegroup of built frontend assets)
         base: base image per arch, as a dict {"amd64": "//my:image_amd64", ...}.
             Defaults to nginx mainline nonroot.
+        architectures: list of architectures to build for (default: all from distro config)
+        owner: uid for static files (default: 65532/nonroot)
+        ownername: uname for static files (default: nonroot)
         strip_prefix: prefix to strip from file paths before placing in /var/www/html.
             Defaults to the current package name.
         distro: distribution to use (default: debian13)
         ignore_cves: list of CVE IDs to ignore in scanning
         visibility: target visibility
     """
-    architectures = NGINX_ARCHITECTURES[distro]
-    if not base:
-        base = {
-            arch: "//distroless/nginx:nginx_mainline_nonroot_" + arch + "_" + distro
-            for arch in architectures
-        }
+    architectures = architectures or NGINX_ARCHITECTURES[distro]
 
     tar(
         name = name + "_statics_layer",
         srcs = srcs,
         mutate = mutate(
-            owner = str(NONROOT),
-            ownername = "nonroot",
+            owner = owner,
+            ownername = ownername,
             package_dir = "/var/www/html",
             strip_prefix = strip_prefix or native.package_name(),
         ),
@@ -49,7 +51,7 @@ def frontend_image(
     [
         oci_image(
             name = name + "_" + arch,
-            base = base[arch],
+            base = base[arch] if base else "//distroless/nginx:nginx_mainline_nonroot_" + arch + "_" + distro,
             layers = [name + "_statics_layer"],
             platform = ARCHITECTURE_PLATFORMS[arch],
             ignore_cves = ignore_cves,
@@ -58,8 +60,9 @@ def frontend_image(
         for arch in architectures
     ]
 
-    image_index(
-        name = name,
-        manifests = [name + "_" + arch for arch in architectures],
-        visibility = visibility,
-    )
+    if len(architectures) > 1:
+        image_index(
+            name = name,
+            manifests = [name + "_" + arch for arch in architectures],
+            visibility = visibility,
+        )

--- a/distroless/nginx/frontend.bzl
+++ b/distroless/nginx/frontend.bzl
@@ -43,7 +43,7 @@ def frontend_image(
         owner = str(NONROOT),
         ownername = "nonroot",
         strip_prefix = None,
-        ignore_cves = None):
+        **kwargs):
     """Build a single-arch frontend image serving static files with nginx.
 
     Provide either srcs (static files) or statics_layer (pre-built tar layer).
@@ -58,7 +58,7 @@ def frontend_image(
         owner: uid for static files (default: 65532/nonroot), only used with srcs
         ownername: uname for static files (default: nonroot), only used with srcs
         strip_prefix: prefix to strip from file paths, only used with srcs
-        ignore_cves: list of CVE IDs to ignore in scanning
+        **kwargs: passed to oci_image (ignore_cves, env, etc.)
     """
     if srcs and statics_layer:
         fail("srcs and statics_layer are mutually exclusive")
@@ -73,7 +73,7 @@ def frontend_image(
         base = base or "//distroless/nginx:nginx_mainline_nonroot_" + arch + "_" + distro,
         layers = [statics_layer],
         platform = ARCHITECTURE_PLATFORMS[arch],
-        ignore_cves = ignore_cves,
+        **kwargs
     )
 
 def frontend_images_all_arch(name, srcs, base = None, distro = "debian13", **kwargs):

--- a/distroless/nginx/nginx.bzl
+++ b/distroless/nginx/nginx.bzl
@@ -38,7 +38,7 @@ def nginx_image(
     [
         oci_image(
             name = name + "_" + version_label + mode + "_" + user + "_" + arch + "_" + distro,
-            base = "//distroless/bash:bash" + mode + "_" + user + "_" + arch + "_" + distro,
+            base = "//distroless/base:base" + mode + "_" + user + "_" + arch + "_" + distro,
             entrypoint = ["/usr/sbin/nginx", "-e", "/dev/stderr", "-g", "daemon off;"],
             ignore_cves = ignore_cves,
             layers = [

--- a/distroless/nginx/nginx.bzl
+++ b/distroless/nginx/nginx.bzl
@@ -1,0 +1,52 @@
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("@rules_img//img:image.bzl", "image_index")
+load("//distroless:distro.bzl", "ARCHITECTURE_PLATFORMS")
+load("//distroless/common:variables.bzl", "DEBUG_MODE", "USERS")
+load("//oci:oci.bzl", "oci_image")
+
+def nginx_image_index(name, version_label, distro, architectures):
+    """nginx image index for a distro
+
+    Args:
+        name: base name of image
+        version_label: stable or mainline
+        distro: name of distribution
+        architectures: all architectures included in index
+    """
+    [
+        image_index(
+            name = name + "_" + version_label + mode + "_" + user + "_" + distro,
+            annotations = {
+                "org.opencontainers.image.description": "Distroless nginx %s image%s" % (version_label, " (debug)" if mode else ""),
+                "org.opencontainers.image.source": "https://github.com/arkeros/senku/blob/main/distroless/nginx/BUILD",
+            },
+            manifests = [
+                name + "_" + version_label + mode + "_" + user + "_" + arch + "_" + distro
+                for arch in architectures
+            ],
+        )
+        for mode in DEBUG_MODE
+        for user in USERS
+    ]
+
+def nginx_image(
+        name,
+        version_label,
+        distro,
+        arch,
+        ignore_cves = None):
+    [
+        oci_image(
+            name = name + "_" + version_label + mode + "_" + user + "_" + arch + "_" + distro,
+            base = "//distroless/bash:bash" + mode + "_" + user + "_" + arch + "_" + distro,
+            entrypoint = ["/usr/sbin/nginx", "-e", "/dev/stderr", "-g", "daemon off;"],
+            ignore_cves = ignore_cves,
+            layers = [
+                "//distroless/nginx:" + version_label + "_" + arch + "_" + distro + "_layer",
+                "//distroless/nginx:nginx_conf_layer",
+            ],
+            platform = ARCHITECTURE_PLATFORMS[arch],
+        )
+        for mode in DEBUG_MODE
+        for user in USERS
+    ]

--- a/distroless/nginx/nginx.conf
+++ b/distroless/nginx/nginx.conf
@@ -1,0 +1,33 @@
+worker_processes auto;
+
+error_log /dev/stderr notice;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    server_tokens off;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /dev/stdout main;
+
+    sendfile on;
+
+    keepalive_timeout 65;
+
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path /tmp/proxy_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/distroless/nginx/test.yaml
+++ b/distroless/nginx/test.yaml
@@ -11,6 +11,11 @@ fileExistenceTests:
   - name: 'default server config exists'
     path: '/etc/nginx/conf.d/default.conf'
     shouldExist: true
+commandTests:
+  - name: 'nginx config is valid'
+    command: '/usr/sbin/nginx'
+    args: ['-t', '-e', '/dev/stderr']
+    exitCode: 0
 fileContentTests:
   - name: 'nginx listens on 8080'
     path: '/etc/nginx/conf.d/default.conf'

--- a/distroless/nginx/test.yaml
+++ b/distroless/nginx/test.yaml
@@ -1,0 +1,17 @@
+schemaVersion: 2.0.0
+metadataTest:
+  entrypoint: ['/usr/sbin/nginx', '-e', '/dev/stderr', '-g', 'daemon off;']
+fileExistenceTests:
+  - name: 'nginx binary exists'
+    path: '/usr/sbin/nginx'
+    shouldExist: true
+  - name: 'nginx config exists'
+    path: '/etc/nginx/nginx.conf'
+    shouldExist: true
+  - name: 'default server config exists'
+    path: '/etc/nginx/conf.d/default.conf'
+    shouldExist: true
+fileContentTests:
+  - name: 'nginx listens on 8080'
+    path: '/etc/nginx/conf.d/default.conf'
+    expectedContents: ['listen 8080']


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds nginx stable and mainline apt repos with version‑pinned lock manifests; exposes all three apt repos.
  * Introduces distroless NGINX images (stable & mainline), multi-arch builds (amd64, arm64), image variants (root/nonroot/debug) and frontend-image macros for static sites.
  * Default server listens on port 8080 with SPA-friendly routing.

* **Tests**
  * Adds container validation tests for nginx binary, configs, and listen-port behavior.

* **Documentation**
  * New README documenting build, usage, variants, and lockfile update steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->