### PR TITLE
feat(panallet): errorElement + 404 catch-all

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -579,7 +579,7 @@
         "recordedInputs": [
           "REPO_MAPPING:aspect_rules_ts+,aspect_rules_ts aspect_rules_ts+",
           "REPO_MAPPING:aspect_rules_ts+,bazel_tools bazel_tools",
-          "FILE:@@//package.json c88a1c7b258113c9c66aa3deed0a659534a530ec17852e5aae69fd5afec0685b"
+          "FILE:@@//package.json c6270d64939210be1456a98c3994c52c3271ab0fe9a8a01819c4e7bad2f6c297"
         ],
         "generatedRepoSpecs": {
           "npm_typescript": {

--- a/devtools/build/react_component/BUILD
+++ b/devtools/build/react_component/BUILD
@@ -48,12 +48,18 @@ js_binary(
 # with typed URL consts. Identifier derivation rules live here.
 js_binary(
     name = "asset_codegen_bin",
+    data = [
+        "//:node_modules/ramda",
+    ],
     entry_point = "asset_codegen.mjs",
 )
 
 js_test(
     name = "asset_codegen_test",
-    data = ["asset_codegen.mjs"],
+    data = [
+        "asset_codegen.mjs",
+        "//:node_modules/ramda",
+    ],
     entry_point = "asset_codegen_test.mjs",
 )
 

--- a/devtools/build/react_component/BUILD
+++ b/devtools/build/react_component/BUILD
@@ -27,6 +27,9 @@ js_binary(
 # Route codegen: generates router.tsx + main.tsx from route manifest
 js_binary(
     name = "react_app_codegen_bin",
+    data = [
+        "//:node_modules/ramda",
+    ],
     entry_point = "react_app_codegen.mjs",
 )
 

--- a/devtools/build/react_component/BUILD
+++ b/devtools/build/react_component/BUILD
@@ -77,6 +77,7 @@ bzl_library(
         ":labels",
         ":react_app_manifest",
         ":react_component",
+        ":route_tree",
         ":stylex_css",
         "//devtools/build/js:devserver",
         "@aspect_rules_esbuild//esbuild:defs",
@@ -149,6 +150,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "react_app_manifest",
+    srcs = ["react_app_manifest.bzl"],
+    deps = [":route_tree"],
+)
+
+bzl_library(
     name = "_artifact_aspect",
     srcs = ["_artifact_aspect.bzl"],
 )
@@ -174,6 +181,6 @@ bzl_library(
 )
 
 bzl_library(
-    name = "react_app_manifest",
-    srcs = ["react_app_manifest.bzl"],
+    name = "route_tree",
+    srcs = ["route_tree.bzl"],
 )

--- a/devtools/build/react_component/asset_codegen.mjs
+++ b/devtools/build/react_component/asset_codegen.mjs
@@ -13,6 +13,7 @@
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
+import * as R from "ramda";
 
 // rules_js' js_binary wrapper cds into bazel-bin but exposes the execroot
 // via this env var — paths from Bazel args are relative to execroot, so
@@ -61,24 +62,46 @@ export function deriveIdentifier(basename) {
   return ident + "Url";
 }
 
+const enrichEntry = ([original, hashed]) => ({
+  original,
+  hashed,
+  ident: deriveIdentifier(original),
+});
+
+// Returns the first ident with more than one originating filename, or
+// undefined if every ident is unique. Groups preserve insertion order, so the
+// returned originals are in the same order as the sorted input.
+const findCollision = R.pipe(
+  R.groupBy(R.prop("ident")),
+  R.toPairs,
+  R.find(([, items]) => items.length > 1),
+);
+
+const emitLine = (normalizedPrefix) => ({ ident, hashed }) =>
+  `export const ${ident}: string = ${JSON.stringify(normalizedPrefix + hashed)};`;
+
 export function generate(manifest, urlPrefix) {
   const normalizedPrefix = urlPrefix.endsWith("/") ? urlPrefix : urlPrefix + "/";
-  const entries = Object.entries(manifest).sort(([a], [b]) => (a < b ? -1 : 1));
-  const byIdent = new Map();
-  const lines = ["// generated — do not edit", ""];
+  const enriched = R.pipe(
+    R.toPairs,
+    R.sortBy(R.head),
+    R.map(enrichEntry),
+  )(manifest);
 
-  for (const [original, hashed] of entries) {
-    const ident = deriveIdentifier(original);
-    const existing = byIdent.get(ident);
-    if (existing) {
-      throw new Error(
-        `asset_codegen: identifier collision — "${existing}" and "${original}" both produce "${ident}". ` +
-          "Rename one or give the files distinct stems.",
-      );
-    }
-    byIdent.set(ident, original);
-    lines.push(`export const ${ident}: string = ${JSON.stringify(normalizedPrefix + hashed)};`);
+  const collision = findCollision(enriched);
+  if (collision) {
+    const [ident, items] = collision;
+    throw new Error(
+      `asset_codegen: identifier collision — "${items[0].original}" and "${items[1].original}" both produce "${ident}". ` +
+        "Rename one or give the files distinct stems.",
+    );
   }
+
+  const lines = [
+    "// generated — do not edit",
+    "",
+    ...R.map(emitLine(normalizedPrefix), enriched),
+  ];
   return lines.join("\n") + "\n";
 }
 

--- a/devtools/build/react_component/react_app.bzl
+++ b/devtools/build/react_component/react_app.bzl
@@ -8,6 +8,7 @@ load(":asset_pipeline.bzl", "asset_pipeline")
 load(":labels.bzl", "ts_dep")
 load(":react_app_manifest.bzl", "react_app_manifest")
 load(":react_component.bzl", "react_component")
+load(":route_tree.bzl", "walk_route_tree")
 load(":stylex_css.bzl", "stylex_css")
 
 def route(path, component = None, children = None):
@@ -50,26 +51,17 @@ def react_app(name, layout, routes, browser_deps, jit_open_props = False, html_t
     """
 
     # Flatten route tree: collect ordered component list and build
-    # index-based route config for the manifest rule (iterative — Starlark
-    # doesn't allow recursion)
+    # index-based route config for the manifest rule.
     ordered_components = []
-    flat_routes = []
-    stack = [(routes, flat_routes)]
-    for _ in range(1000):
-        if not stack:
-            break
-        route_list, output = stack.pop()
-        for r in route_list:
-            entry = {"path": r["path"]}
-            if "component" in r:
-                entry["component_idx"] = len(ordered_components)
-                ordered_components.append(r["component"])
-            if "children" in r:
-                entry["children"] = []
-                stack.append((r["children"], entry["children"]))
-            output.append(entry)
-    if stack:
-        fail("route tree flattening exceeded 1000 iterations; route manifest would be truncated")
+
+    def _collect(r):
+        if "component" not in r:
+            return {}
+        idx = len(ordered_components)
+        ordered_components.append(r["component"])
+        return {"component_idx": idx}
+
+    flat_routes = walk_route_tree(routes, _collect)
 
     all_route_components = [layout] + ordered_components
 

--- a/devtools/build/react_component/react_app.bzl
+++ b/devtools/build/react_component/react_app.bzl
@@ -11,22 +11,30 @@ load(":react_component.bzl", "react_component")
 load(":route_tree.bzl", "walk_route_tree")
 load(":stylex_css.bzl", "stylex_css")
 
-def route(path, component = None, children = None):
+def route(path, component = None, children = None, error_component = None):
     """Define a route mapping a URL path to a react_component target.
 
     Args:
-        path: URL path (e.g. "/", "about", ":city")
+        path: URL path (e.g. "/", "about", ":city"). `"*"` is a catch-all
+            (rendered when no other route matches — use for 404 pages).
         component: label of a react_component target (optional for grouping routes)
         children: list of nested route() dicts (optional)
+        error_component: label of a react_component target rendered when this
+            route (or any descendant without its own error_component) throws.
+            Compiles to React Router's `errorElement`. The component is
+            statically imported at the top of the generated router so it is
+            available even when a lazy Component import fails.
     """
     r = {"path": path}
     if component:
         r["component"] = component
     if children:
         r["children"] = children
+    if error_component:
+        r["error_component"] = error_component
     return r
 
-def react_app(name, layout, routes, browser_deps, jit_open_props = False, html_template = None, **kwargs):
+def react_app(name, layout, routes, browser_deps, error_component = None, jit_open_props = False, html_template = None, **kwargs):
     """Build a React application with Starlark-defined routes and lazy loading.
 
     Routes are defined in BUILD files and compiled to React Router's
@@ -46,6 +54,9 @@ def react_app(name, layout, routes, browser_deps, jit_open_props = False, html_t
         layout: label of the root layout react_component (renders <Outlet />)
         routes: list of route() dicts (supports nesting)
         browser_deps: list of browser_dep labels for the devserver
+        error_component: optional label of a react_component rendered when the
+            layout or any route without its own error_component throws. Acts as
+            the app-wide error boundary.
         html_template: optional custom HTML template (defaults to built-in)
         **kwargs: passed through to downstream targets (e.g. visibility, tags)
     """
@@ -55,21 +66,27 @@ def react_app(name, layout, routes, browser_deps, jit_open_props = False, html_t
     ordered_components = []
 
     def _collect(r):
-        if "component" not in r:
-            return {}
-        idx = len(ordered_components)
-        ordered_components.append(r["component"])
-        return {"component_idx": idx}
+        fields = {}
+        if "component" in r:
+            fields["component_idx"] = len(ordered_components)
+            ordered_components.append(r["component"])
+        if "error_component" in r:
+            fields["error_component_idx"] = len(ordered_components)
+            ordered_components.append(r["error_component"])
+        return fields
 
     flat_routes = walk_route_tree(routes, _collect)
 
     all_route_components = [layout] + ordered_components
+    if error_component:
+        all_route_components = all_route_components + [error_component]
 
     # Generate route manifest — looks up .js entries from each target's DefaultInfo
     manifest_name = name + "_manifest"
     react_app_manifest(
         name = manifest_name,
         layout = layout,
+        layout_error_component = error_component,
         route_components = ordered_components,
         route_config = json.encode(flat_routes),
     )

--- a/devtools/build/react_component/react_app.bzl
+++ b/devtools/build/react_component/react_app.bzl
@@ -62,24 +62,38 @@ def react_app(name, layout, routes, browser_deps, error_component = None, jit_op
     """
 
     # Flatten route tree: collect ordered component list and build
-    # index-based route config for the manifest rule.
+    # index-based route config for the manifest rule. Dedupe by label so a
+    # component referenced in multiple routes (e.g. a shared error_component)
+    # appears once — Bazel rejects duplicate labels in label_list attrs.
     ordered_components = []
+    idx_by_component = {}
+
+    def _intern(c):
+        idx = idx_by_component.get(c)
+        if idx == None:
+            idx = len(ordered_components)
+            idx_by_component[c] = idx
+            ordered_components.append(c)
+        return idx
 
     def _collect(r):
         fields = {}
         if "component" in r:
-            fields["component_idx"] = len(ordered_components)
-            ordered_components.append(r["component"])
+            fields["component_idx"] = _intern(r["component"])
         if "error_component" in r:
-            fields["error_component_idx"] = len(ordered_components)
-            ordered_components.append(r["error_component"])
+            fields["error_component_idx"] = _intern(r["error_component"])
         return fields
 
     flat_routes = walk_route_tree(routes, _collect)
 
-    all_route_components = [layout] + ordered_components
-    if error_component:
-        all_route_components = all_route_components + [error_component]
+    # Dedupe across buckets too (layout / app-level error_component may
+    # overlap with route components) before fan-out to downstream rules.
+    seen = {}
+    all_route_components = []
+    for c in [layout] + ordered_components + ([error_component] if error_component else []):
+        if c not in seen:
+            seen[c] = True
+            all_route_components.append(c)
 
     # Generate route manifest — looks up .js entries from each target's DefaultInfo
     manifest_name = name + "_manifest"

--- a/devtools/build/react_component/react_app_codegen.mjs
+++ b/devtools/build/react_component/react_app_codegen.mjs
@@ -31,20 +31,58 @@ const routerModuleName = "./" + outRouter.split("/").pop().replace(/\.tsx$/, "")
 // Collect error components as top-of-file static imports. Error boundaries
 // must be synchronously available — if a lazy Component fails to load, a
 // lazy errorElement could fail the same way and mask the real error.
-const errorImports = new Map(); // name -> relative import path
+//
+// Two different packages may export the same error-component name (manifest
+// uses the component's exported identifier, which is not globally unique).
+// Key by (importPath, name) and alias same-named imports to a locally unique
+// identifier so they can coexist in the generated router module.
+const errorImports = new Map(); // `${path}\0${name}` -> { name, path, localName }
+
+function makeErrorImportKey(importPath, name) {
+  return `${importPath}\0${name}`;
+}
+
+function toIdentifierSuffix(value) {
+  return value.replace(/[^A-Za-z0-9_$]+/g, "_").replace(/^([^A-Za-z_$])/, "_$1");
+}
+
+function getErrorImportLocalName(importPath, name) {
+  const key = makeErrorImportKey(importPath, name);
+  const existing = errorImports.get(key);
+  if (existing) return existing.localName;
+
+  let localName = name;
+  if (Array.from(errorImports.values()).some((entry) => entry.localName === localName)) {
+    localName = `${name}__${toIdentifierSuffix(importPath)}`;
+  }
+
+  errorImports.set(key, { name, path: importPath, localName });
+  return localName;
+}
+
 function collectErrorImports(routes) {
   for (const r of routes) {
-    if (r.error_name) errorImports.set(r.error_name, r.error_import);
+    if (r.error_name && r.error_import) {
+      r.error_name = getErrorImportLocalName(r.error_import, r.error_name);
+    }
     if (r.children) collectErrorImports(r.children);
   }
 }
-if (manifest.layout.error_name) {
-  errorImports.set(manifest.layout.error_name, manifest.layout.error_import);
+
+if (manifest.layout.error_name && manifest.layout.error_import) {
+  manifest.layout.error_name = getErrorImportLocalName(
+    manifest.layout.error_import,
+    manifest.layout.error_name,
+  );
 }
 collectErrorImports(manifest.routes);
 
-const errorImportLines = Array.from(errorImports.entries())
-  .map(([name, path]) => `import { ${name} } from "${path}";`)
+const errorImportLines = Array.from(errorImports.values())
+  .map(({ name, path, localName }) =>
+    localName === name
+      ? `import { ${name} } from "${path}";`
+      : `import { ${name} as ${localName} } from "${path}";`,
+  )
   .join("\n");
 
 // Generate lazy route objects recursively

--- a/devtools/build/react_component/react_app_codegen.mjs
+++ b/devtools/build/react_component/react_app_codegen.mjs
@@ -9,6 +9,7 @@
  */
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import * as R from "ramda";
 
 const args = process.argv.slice(2);
 let manifestFile, outRouter, outMain;
@@ -28,54 +29,55 @@ const execroot = process.env.JS_BINARY__EXECROOT || process.cwd();
 const manifest = JSON.parse(readFileSync(resolve(execroot, manifestFile), "utf-8"));
 const routerModuleName = "./" + outRouter.split("/").pop().replace(/\.tsx$/, "");
 
-// Collect error components as top-of-file static imports. Error boundaries
-// must be synchronously available — if a lazy Component fails to load, a
-// lazy errorElement could fail the same way and mask the real error.
+// Error boundaries must be statically imported — a lazy boundary risks the
+// same failure that triggered it, masking the real error. We resolve each
+// (importPath, name) to a locally unique identifier in a single pass, then
+// look it up during route generation; the manifest is never mutated.
 //
-// Two different packages may export the same error-component name (manifest
-// uses the component's exported identifier, which is not globally unique).
-// Key by (importPath, name) and alias same-named imports to a locally unique
-// identifier so they can coexist in the generated router module.
-const errorImports = new Map(); // `${path}\0${name}` -> { name, path, localName }
+// Two packages may export error components with the same name (manifest uses
+// the exported identifier, which isn't globally unique). First seen wins the
+// original identifier; later (path, name) entries are aliased with a
+// path-derived suffix.
 
-function makeErrorImportKey(importPath, name) {
-  return `${importPath}\0${name}`;
-}
+const toIdentifierSuffix = R.pipe(
+  R.replace(/[^A-Za-z0-9_$]+/g, "_"),
+  R.replace(/^([^A-Za-z_$])/, "_$1"),
+);
 
-function toIdentifierSuffix(value) {
-  return value.replace(/[^A-Za-z0-9_$]+/g, "_").replace(/^([^A-Za-z_$])/, "_$1");
-}
+const hasErrorRef = (r) => Boolean(r.error_name && r.error_import);
+const errorKey = (r) => `${r.error_import}\0${r.error_name}`;
 
-function getErrorImportLocalName(importPath, name) {
-  const key = makeErrorImportKey(importPath, name);
-  const existing = errorImports.get(key);
-  if (existing) return existing.localName;
+// Depth-first flatten of the nested route tree.
+const flattenRoutes = R.chain((r) =>
+  r.children ? [r, ...flattenRoutes(r.children)] : [r],
+);
 
-  let localName = name;
-  if (Array.from(errorImports.values()).some((entry) => entry.localName === localName)) {
-    localName = `${name}__${toIdentifierSuffix(importPath)}`;
-  }
+// All error-component references in traversal order (layout first).
+const collectErrorRefs = (m) =>
+  R.filter(hasErrorRef, [m.layout, ...flattenRoutes(m.routes)]);
 
-  errorImports.set(key, { name, path: importPath, localName });
-  return localName;
-}
+// Resolve (path, name) -> { path, name, localName }, aliasing collisions.
+const buildErrorImportTable = R.pipe(
+  R.uniqBy(errorKey),
+  (refs) =>
+    R.mapAccum(
+      (seen, ref) => {
+        const { error_import: path, error_name: name } = ref;
+        const localName = seen.has(name)
+          ? `${name}__${toIdentifierSuffix(path)}`
+          : name;
+        return [new Set(seen).add(name), [errorKey(ref), { path, name, localName }]];
+      },
+      new Set(),
+      refs,
+    )[1],
+  (entries) => new Map(entries),
+);
 
-function collectErrorImports(routes) {
-  for (const r of routes) {
-    if (r.error_name && r.error_import) {
-      r.error_name = getErrorImportLocalName(r.error_import, r.error_name);
-    }
-    if (r.children) collectErrorImports(r.children);
-  }
-}
+const errorImports = buildErrorImportTable(collectErrorRefs(manifest));
 
-if (manifest.layout.error_name && manifest.layout.error_import) {
-  manifest.layout.error_name = getErrorImportLocalName(
-    manifest.layout.error_import,
-    manifest.layout.error_name,
-  );
-}
-collectErrorImports(manifest.routes);
+const resolveErrorLocalName = (path, name) =>
+  errorImports.get(`${path}\0${name}`).localName;
 
 const errorImportLines = Array.from(errorImports.values())
   .map(({ name, path, localName }) =>
@@ -100,8 +102,9 @@ function generateRoute(route, indent) {
     props.push(`lazy: () => import("${route.import}").then(m => ({ Component: m.${route.name} }))`);
   }
 
-  if (route.error_name) {
-    props.push(`errorElement: <${route.error_name} />`);
+  if (hasErrorRef(route)) {
+    const localName = resolveErrorLocalName(route.error_import, route.error_name);
+    props.push(`errorElement: <${localName} />`);
   }
 
   if (route.children && route.children.length > 0) {
@@ -120,8 +123,8 @@ function generateRoute(route, indent) {
 const routeEntries = manifest.routes.map((r) => generateRoute(r, 6));
 const layout = manifest.layout;
 
-const layoutErrorLine = layout.error_name
-  ? `    errorElement: <${layout.error_name} />,\n`
+const layoutErrorLine = hasErrorRef(layout)
+  ? `    errorElement: <${resolveErrorLocalName(layout.error_import, layout.error_name)} />,\n`
   : "";
 
 const errorImportsBlock = errorImportLines ? errorImportLines + "\n" : "";

--- a/devtools/build/react_component/react_app_codegen.mjs
+++ b/devtools/build/react_component/react_app_codegen.mjs
@@ -28,50 +28,74 @@ const execroot = process.env.JS_BINARY__EXECROOT || process.cwd();
 const manifest = JSON.parse(readFileSync(resolve(execroot, manifestFile), "utf-8"));
 const routerModuleName = "./" + outRouter.split("/").pop().replace(/\.tsx$/, "");
 
+// Collect error components as top-of-file static imports. Error boundaries
+// must be synchronously available — if a lazy Component fails to load, a
+// lazy errorElement could fail the same way and mask the real error.
+const errorImports = new Map(); // name -> relative import path
+function collectErrorImports(routes) {
+  for (const r of routes) {
+    if (r.error_name) errorImports.set(r.error_name, r.error_import);
+    if (r.children) collectErrorImports(r.children);
+  }
+}
+if (manifest.layout.error_name) {
+  errorImports.set(manifest.layout.error_name, manifest.layout.error_import);
+}
+collectErrorImports(manifest.routes);
+
+const errorImportLines = Array.from(errorImports.entries())
+  .map(([name, path]) => `import { ${name} } from "${path}";`)
+  .join("\n");
+
 // Generate lazy route objects recursively
 function generateRoute(route, indent) {
   const pad = " ".repeat(indent);
+  const props = [];
 
   if (route.path === "/") {
-    // Index route
-    if (route.import) {
-      return `${pad}{ index: true, lazy: () => import("${route.import}").then(m => ({ Component: m.${route.name} })) }`;
-    }
-    return `${pad}{ index: true }`;
+    props.push("index: true");
+  } else {
+    props.push(`path: "${route.path}"`);
   }
 
-  const parts = [`${pad}{ path: "${route.path}"`];
-
   if (route.import) {
-    parts[0] += `, lazy: () => import("${route.import}").then(m => ({ Component: m.${route.name} }))`;
+    props.push(`lazy: () => import("${route.import}").then(m => ({ Component: m.${route.name} }))`);
+  }
+
+  if (route.error_name) {
+    props.push(`errorElement: <${route.error_name} />`);
   }
 
   if (route.children && route.children.length > 0) {
-    parts[0] += `, children: [`;
+    const lines = [`${pad}{ ${props.join(", ")}, children: [`];
     for (let i = 0; i < route.children.length; i++) {
-      parts.push(generateRoute(route.children[i], indent + 2));
-      if (i < route.children.length - 1) {
-        parts[parts.length - 1] += ",";
-      }
+      const childLine = generateRoute(route.children[i], indent + 2);
+      lines.push(i < route.children.length - 1 ? childLine + "," : childLine);
     }
-    parts.push(`${pad}]`);
+    lines.push(`${pad}] }`);
+    return lines.join("\n");
   }
 
-  parts[parts.length - 1] += " }";
-  return parts.join("\n");
+  return `${pad}{ ${props.join(", ")} }`;
 }
 
 const routeEntries = manifest.routes.map((r) => generateRoute(r, 6));
 const layout = manifest.layout;
 
-// router.tsx — lazy imports only, no static imports needed
-const routerCode = `import { createBrowserRouter } from "react-router";
+const layoutErrorLine = layout.error_name
+  ? `    errorElement: <${layout.error_name} />,\n`
+  : "";
 
+const errorImportsBlock = errorImportLines ? errorImportLines + "\n" : "";
+
+// router.tsx — lazy imports for route components, static imports for error boundaries
+const routerCode = `import { createBrowserRouter } from "react-router";
+${errorImportsBlock}
 export const router = createBrowserRouter([
   {
     path: "/",
     lazy: () => import("${layout.import}").then(m => ({ Component: m.${layout.name} })),
-    children: [
+${layoutErrorLine}    children: [
 ${routeEntries.join(",\n")},
     ],
   },

--- a/devtools/build/react_component/react_app_manifest.bzl
+++ b/devtools/build/react_component/react_app_manifest.bzl
@@ -61,21 +61,30 @@ def _react_app_manifest_impl(ctx):
             return "./" + rel + "/" + file_base if rel else "./" + file_base
 
     def _enrich(r):
-        if "component_idx" not in r:
-            return {}
-        idx = r["component_idx"]
-        return {
-            "import": _rel_path(route_js[idx]),
-            "name": route_names[idx],
-        }
+        fields = {}
+        if "component_idx" in r:
+            idx = r["component_idx"]
+            fields["import"] = _rel_path(route_js[idx])
+            fields["name"] = route_names[idx]
+        if "error_component_idx" in r:
+            idx = r["error_component_idx"]
+            fields["error_import"] = _rel_path(route_js[idx])
+            fields["error_name"] = route_names[idx]
+        return fields
 
     enriched_routes = walk_route_tree(route_config, _enrich)
 
+    layout_entry = {
+        "import": _rel_path(layout_js),
+        "name": layout_name,
+    }
+    if ctx.attr.layout_error_component:
+        err_target = ctx.attr.layout_error_component
+        layout_entry["error_import"] = _rel_path(_find_js_entry(err_target))
+        layout_entry["error_name"] = err_target.label.name
+
     manifest = {
-        "layout": {
-            "import": _rel_path(layout_js),
-            "name": layout_name,
-        },
+        "layout": layout_entry,
         "routes": enriched_routes,
     }
 
@@ -92,6 +101,9 @@ react_app_manifest = rule(
         "layout": attr.label(
             mandatory = True,
             doc = "The layout react_component target",
+        ),
+        "layout_error_component": attr.label(
+            doc = "Optional react_component rendered as the app-wide errorElement on the layout route",
         ),
         "route_components": attr.label_list(
             doc = "Ordered list of route react_component targets (indexed by route_config)",

--- a/devtools/build/react_component/react_app_manifest.bzl
+++ b/devtools/build/react_component/react_app_manifest.bzl
@@ -1,5 +1,7 @@
 "Rule that generates a route manifest from component targets"
 
+load(":route_tree.bzl", "walk_route_tree")
+
 def _find_js_entry(target):
     """Return the .js File in target's DefaultInfo whose basename is {name}.js.
 
@@ -58,26 +60,16 @@ def _react_app_manifest_impl(ctx):
                 rel = rel + "/" + downs if rel else downs
             return "./" + rel + "/" + file_base if rel else "./" + file_base
 
-    # Enrich route config with actual import paths (iterative)
-    enriched_routes = []
-    stack = [(route_config, enriched_routes)]
-    for _ in range(1000):
-        if not stack:
-            break
-        routes_in, routes_out = stack.pop()
-        for r in routes_in:
-            entry = {"path": r["path"]}
-            if "component_idx" in r:
-                idx = r["component_idx"]
-                entry["import"] = _rel_path(route_js[idx])
-                entry["name"] = route_names[idx]
-            if "children" in r:
-                entry["children"] = []
-                stack.append((r["children"], entry["children"]))
-            routes_out.append(entry)
+    def _enrich(r):
+        if "component_idx" not in r:
+            return {}
+        idx = r["component_idx"]
+        return {
+            "import": _rel_path(route_js[idx]),
+            "name": route_names[idx],
+        }
 
-    if stack:
-        fail("Route tree too deep (exceeded 1000 iterations). Simplify route structure or increase limit.")
+    enriched_routes = walk_route_tree(route_config, _enrich)
 
     manifest = {
         "layout": {

--- a/devtools/build/react_component/route_tree.bzl
+++ b/devtools/build/react_component/route_tree.bzl
@@ -1,0 +1,32 @@
+"Shared iterative walker for the panallet route tree (Starlark forbids recursion)."
+
+_MAX_DEPTH = 1000
+
+def walk_route_tree(routes, visit):
+    """Walk routes in pre-order, producing a parallel tree.
+
+    For each input route dict, the returned tree contains {"path": r["path"]}
+    merged with whatever fields `visit(r)` returns. If the input route has
+    "children", they are recursed into and attached as "children" on the output.
+
+    Args:
+        routes: list of route dicts (each must have "path")
+        visit: fn(route_dict) -> dict of extra fields for the output entry
+
+    Returns:
+        list of transformed route dicts
+    """
+    output = []
+    stack = [(routes, output)]
+    for _ in range(_MAX_DEPTH):
+        if not stack:
+            return output
+        routes_in, routes_out = stack.pop()
+        for r in routes_in:
+            entry = {"path": r["path"]}
+            entry.update(visit(r))
+            if "children" in r:
+                entry["children"] = []
+                stack.append((r["children"], entry["children"]))
+            routes_out.append(entry)
+    fail("route tree exceeded {} iterations; structure too deep or cyclic".format(_MAX_DEPTH))

--- a/devtools/build/react_component/route_tree.bzl
+++ b/devtools/build/react_component/route_tree.bzl
@@ -3,11 +3,18 @@
 _MAX_DEPTH = 1000
 
 def walk_route_tree(routes, visit):
-    """Walk routes in pre-order, producing a parallel tree.
+    """Walk routes iteratively, producing a parallel tree.
+
+    Parent entries are created before any of their descendants, but this is not
+    a strict depth-first pre-order traversal: all siblings in the current input
+    list are processed before descending into children, and because pending
+    child lists are stored on a LIFO stack, the last sibling's children are
+    processed first.
 
     For each input route dict, the returned tree contains {"path": r["path"]}
     merged with whatever fields `visit(r)` returns. If the input route has
-    "children", they are recursed into and attached as "children" on the output.
+    "children", they are iteratively processed and attached as "children" on
+    the output.
 
     Args:
         routes: list of route dicts (each must have "path")

--- a/examples/stylex/AppError.tsx
+++ b/examples/stylex/AppError.tsx
@@ -1,0 +1,24 @@
+import * as stylex from "@stylexjs/stylex";
+import { useRouteError } from "react-router";
+import { color, size } from "./tokens.stylex";
+
+const styles = stylex.create({
+  wrap: {
+    padding: size.m,
+    borderTop: `4px solid ${color.primary}`,
+  },
+  message: {
+    color: color.primary,
+  },
+});
+
+export function AppError() {
+  const error = useRouteError();
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    <div {...stylex.props(styles.wrap)}>
+      <h1>Something went wrong</h1>
+      <pre {...stylex.props(styles.message)}>{message}</pre>
+    </div>
+  );
+}

--- a/examples/stylex/BUILD
+++ b/examples/stylex/BUILD
@@ -28,6 +28,24 @@ react_component(
     ],
 )
 
+react_component(
+    name = "AppError",
+    srcs = ["AppError.tsx"],
+    deps = [
+        ":tokens",
+        "//:node_modules/react-router",
+    ],
+)
+
+react_component(
+    name = "RouteError",
+    srcs = ["RouteError.tsx"],
+    deps = [
+        ":tokens",
+        "//:node_modules/react-router",
+    ],
+)
+
 react_app(
     name = "app",
     browser_deps = [
@@ -37,6 +55,7 @@ react_app(
         "//devtools/build/js:set_cookie_parser",
         "//devtools/build/js:stylex",
     ],
+    error_component = ":AppError",
     html_template = "index.html.tpl",
     jit_open_props = True,
     layout = ":Layout",
@@ -47,6 +66,7 @@ react_app(
         ),
         route(
             component = "//examples/stylex/pages:About",
+            error_component = ":RouteError",
             path = "about",
         ),
         route(
@@ -65,6 +85,10 @@ react_app(
                 ),
             ],
             path = "concerts",
+        ),
+        route(
+            component = "//examples/stylex/pages:NotFound",
+            path = "*",
         ),
     ],
 )

--- a/examples/stylex/BUILD
+++ b/examples/stylex/BUILD
@@ -73,6 +73,7 @@ react_app(
             children = [
                 route(
                     component = "//examples/stylex/pages/concerts:ConcertsHome",
+                    error_component = ":RouteError",
                     path = "/",
                 ),
                 route(

--- a/examples/stylex/RouteError.tsx
+++ b/examples/stylex/RouteError.tsx
@@ -1,0 +1,19 @@
+import * as stylex from "@stylexjs/stylex";
+import { useRouteError } from "react-router";
+import { size } from "./tokens.stylex";
+
+const styles = stylex.create({
+  wrap: {
+    padding: size.s,
+  },
+});
+
+export function RouteError() {
+  const error = useRouteError();
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    <div {...stylex.props(styles.wrap)}>
+      <p>This page failed to load: {message}</p>
+    </div>
+  );
+}

--- a/examples/stylex/app_test.sh
+++ b/examples/stylex/app_test.sh
@@ -14,6 +14,15 @@ grep -q 'createBrowserRouter' "$ROUTER" || { echo "FAIL: missing createBrowserRo
 grep -q 'path: "concerts"' "$ROUTER" || { echo "FAIL: missing concerts route"; exit 1; }
 grep -q 'path: ":city"' "$ROUTER" || { echo "FAIL: missing :city param route"; exit 1; }
 grep -q 'Component: m.Layout' "$ROUTER" || { echo "FAIL: missing Layout component reference"; exit 1; }
+# errorElement + 404 support (#94). JSX compiles <Name /> to _jsx(Name, {}),
+# so assert on the compiled form here — the source shape is covered by the
+# router_ts typecheck test.
+grep -q 'import { AppError }' "$ROUTER" || { echo "FAIL: missing AppError static import"; exit 1; }
+grep -q 'import { RouteError }' "$ROUTER" || { echo "FAIL: missing RouteError static import"; exit 1; }
+grep -q 'errorElement: .*_jsx(AppError' "$ROUTER" || { echo "FAIL: missing app-level errorElement"; exit 1; }
+grep -q 'errorElement: .*_jsx(RouteError' "$ROUTER" || { echo "FAIL: missing route-level errorElement"; exit 1; }
+grep -q 'path: "\*"' "$ROUTER" || { echo "FAIL: missing 404 catch-all path"; exit 1; }
+grep -q 'import("./pages/NotFound")' "$ROUTER" || { echo "FAIL: missing NotFound lazy import"; exit 1; }
 echo "PASS: router"
 
 # Test generated main entry point

--- a/examples/stylex/pages/BUILD
+++ b/examples/stylex/pages/BUILD
@@ -13,3 +13,12 @@ react_component(
     srcs = ["About.tsx"],
     deps = ["//examples/stylex:tokens"],
 )
+
+react_component(
+    name = "NotFound",
+    srcs = ["NotFound.tsx"],
+    deps = [
+        "//:node_modules/react-router",
+        "//examples/stylex:tokens",
+    ],
+)

--- a/examples/stylex/pages/NotFound.tsx
+++ b/examples/stylex/pages/NotFound.tsx
@@ -1,0 +1,28 @@
+import * as stylex from "@stylexjs/stylex";
+import { Link, useLocation } from "react-router";
+import { color, font, size } from "../tokens.stylex";
+
+const styles = stylex.create({
+  wrap: {
+    padding: size.m,
+  },
+  heading: {
+    fontSize: 32,
+    fontWeight: font.weight5,
+    marginBottom: size.s,
+  },
+  link: {
+    color: color.primary,
+  },
+});
+
+export function NotFound() {
+  const { pathname } = useLocation();
+  return (
+    <div {...stylex.props(styles.wrap)}>
+      <h1 {...stylex.props(styles.heading)}>404</h1>
+      <p>No route matched <code>{pathname}</code>.</p>
+      <Link to="/" {...stylex.props(styles.link)}>Back home</Link>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/react-dom": "^19.2.3",
     "esbuild": "^0.28.0",
     "mime": "^4.1.0",
+    "ramda": "^0.32.0",
     "relay-compiler": "^20.1.1",
     "typescript": "6.0.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       mime:
         specifier: ^4.1.0
         version: 4.1.0
+      ramda:
+        specifier: ^0.32.0
+        version: 0.32.0
       relay-compiler:
         specifier: ^20.1.1
         version: 20.1.1
@@ -775,6 +778,9 @@ packages:
 
   promise@7.3.1:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
+
+  ramda@0.32.0:
+    resolution: {integrity: sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==}
 
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
@@ -1574,6 +1580,8 @@ snapshots:
   promise@7.3.1:
     dependencies:
       asap: 2.0.6
+
+  ramda@0.32.0: {}
 
   react-dom@19.2.5(react@19.2.5):
     dependencies:


### PR DESCRIPTION
## Summary

- **#96 / commit 1** — extract shared `walk_route_tree(routes, visit)` helper into `devtools/build/react_component/route_tree.bzl`. `react_app.bzl` and `react_app_manifest.bzl` now share one iteration skeleton; each passes a closure visitor for its side of the transform. Generated `router.tsx` and `manifest.json` on `//examples/stylex` are byte-identical to the pre-refactor output — pure structural change.
- **#94 / commit 2** — `route(error_component=...)` and `react_app(error_component=...)` thread a label through the walker → manifest rule → codegen. Compiles to React Router's `errorElement`. `path = "*"` flows through unchanged as the catch-all.

## Design notes

- **Error components are statically imported, not lazy.** A lazy boundary risks a render loop if the boundary's own import is what fails — the exact case boundaries exist to catch. Regular route components stay lazy.
- **`layout_error_component` is a new attr on the manifest rule**, resolved via the same `_find_js_entry` lookup used for layout/route components. No new provider plumbing.
- **Dedupe landed before the feature on purpose.** Adding `error_component` touches the walker; keeping two copies would have meant the exact anti-pattern #96 exists to prevent.

## Example app wiring (`//examples/stylex`)

Demonstrates all three shapes:
- `react_app(error_component = ":AppError")` — app-wide boundary on the layout route.
- `route(path = "about", ..., error_component = ":RouteError")` — per-route boundary.
- `route(path = "*", component = "//examples/stylex/pages:NotFound")` — 404.

## Test plan

- [x] `bazel test //examples/stylex/...` — 27 tests pass, including the new `AppError_export_test`, `RouteError_export_test`, `NotFound_export_test`, and their typechecks.
- [x] `app_test.sh` greps the compiled `app_router.js` for both static imports, both `errorElement: _jsx(...)` calls, `path: "*"`, and `import("./pages/NotFound")`.
- [x] `bazel build //examples/stylex:app_bundle //examples/stylex:app_html` — production bundle builds cleanly.
- [x] Commit 1 verified with a byte-for-byte diff of `app_router.tsx` and `app_manifest.json` against their pre-refactor outputs.
- [ ] Manual browser check on `bazel run //examples/stylex:app_devserver` — not done; `/unknown` should render NotFound, a throwing About should render RouteError, a throwing Layout should render AppError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added error boundary support for app-level error handling with customizable error components
  * Added route-level error handling with dedicated error components
  * Added catch-all 404 route for unmatched navigation paths

* **Tests**
  * Enhanced router validation to verify error boundary and 404 route configuration

* **Chores**
  * Updated internal dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->