### PR TITLE
feat(bifrost): add terraform modules for service and cronjob workloads

### DIFF
--- a/devtools/bifrost/terraform/modules/BUILD
+++ b/devtools/bifrost/terraform/modules/BUILD
@@ -1,0 +1,4 @@
+exports_files([
+    "fmt_check.sh",
+    "validate.sh",
+])

--- a/devtools/bifrost/terraform/modules/cronjob_cloudrun/BUILD
+++ b/devtools/bifrost/terraform/modules/cronjob_cloudrun/BUILD
@@ -1,0 +1,30 @@
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+_HCL_SRCS = glob(
+    ["**/*.tf"],
+    allow_empty = False,
+)
+
+filegroup(
+    name = "module",
+    srcs = _HCL_SRCS,
+    visibility = ["//visibility:public"],
+)
+
+# Lint, not a test. Semantic validation requires provider downloads; see
+# :validate for the local-only target.
+sh_test(
+    name = "lint",
+    size = "small",
+    srcs = ["//devtools/bifrost/terraform/modules:fmt_check.sh"],
+    args = ["$(rootpath @multitool//tools/terraform)"],
+    data = _HCL_SRCS + ["@multitool//tools/terraform"],
+)
+
+sh_binary(
+    name = "validate",
+    srcs = ["//devtools/bifrost/terraform/modules:validate.sh"],
+    args = ["$(rootpath @multitool//tools/terraform)"],
+    data = _HCL_SRCS + ["@multitool//tools/terraform"],
+)

--- a/devtools/bifrost/terraform/modules/cronjob_cloudrun/README.md
+++ b/devtools/bifrost/terraform/modules/cronjob_cloudrun/README.md
@@ -1,0 +1,34 @@
+# `cronjob_cloudrun` Terraform module (PoC)
+
+Cloud Run Job triggered by Cloud Scheduler, provisioned via the google provider. This module does not touch Kubernetes — the Cloud Run control plane is the reconciler.
+
+> **Status:** proof of concept.
+
+## What it creates
+
+- `google_service_account` (runtime) — identity the Cloud Run Job runs as.
+- `google_service_account` (scheduler) — identity Cloud Scheduler uses to invoke the Job.
+- `google_project_iam_member` — `roles/run.invoker` on the scheduler SA.
+- `google_cloud_run_v2_job` — the Job definition.
+- `google_cloud_scheduler_job` — HTTP trigger posting to the Job's `:run` endpoint.
+
+## The Google resource standard
+
+Cloud Run exposes a single `resources.limits` block covering both CPU and memory; there is no request/limit split. The module maps `resources = { cpu, memory }` directly to those limits.
+
+## Secrets
+
+Cloud Run natively references Secret Manager via `env.value_source.secret_key_ref`. No K8s Secret, no ESO, no content hashing — the Cloud Run control plane handles resolution. `"latest"` remains rejected; version is explicit.
+
+## SSA
+
+Not applicable — Cloud Run isn't Kubernetes. This module uses typed `google_*` resources exclusively.
+
+## Inputs / outputs / verification
+
+See [`variables.tf`](./variables.tf), [`outputs.tf`](./outputs.tf).
+
+```bash
+bazel test //devtools/bifrost/terraform/modules/cronjob_cloudrun:lint
+bazel run  //devtools/bifrost/terraform/modules/cronjob_cloudrun:validate
+```

--- a/devtools/bifrost/terraform/modules/cronjob_cloudrun/examples/basic/main.tf
+++ b/devtools/bifrost/terraform/modules/cronjob_cloudrun/examples/basic/main.tf
@@ -1,0 +1,44 @@
+terraform {
+  required_version = ">= 1.14.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+  }
+}
+
+provider "google" {
+  project = "senku-prod"
+  region  = "europe-west1"
+}
+
+module "daily_report" {
+  source = "../.."
+
+  name       = "daily-report"
+  project_id = "senku-prod"
+  region     = "europe-west1"
+
+  image     = "europe-docker.pkg.dev/senku-prod/jobs/daily-report@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+  resources = { cpu = 1, memory = 512 }
+
+  schedule = {
+    cron      = "0 8 * * *"
+    time_zone = "Europe/Madrid"
+  }
+
+  secret_env = {
+    REPORT_API_KEY = {
+      project = "senku-prod"
+      secret  = "report-api-key"
+      version = "2"
+    }
+  }
+
+  cloud_scheduler = {
+    retry_count              = 2
+    attempt_deadline_seconds = 300
+  }
+}

--- a/devtools/bifrost/terraform/modules/cronjob_cloudrun/main.tf
+++ b/devtools/bifrost/terraform/modules/cronjob_cloudrun/main.tf
@@ -1,0 +1,99 @@
+locals {
+  runtime_sa_id   = coalesce(var.service_account_id, "crj-${var.name}")
+  scheduler_sa_id = "sch-${var.name}"
+  memory_quantity = "${var.resources.memory}Mi"
+}
+
+resource "google_service_account" "runtime" {
+  project      = var.project_id
+  account_id   = local.runtime_sa_id
+  display_name = "Runtime identity for cronjob ${var.name}"
+}
+
+resource "google_service_account" "scheduler" {
+  project      = var.project_id
+  account_id   = local.scheduler_sa_id
+  display_name = "Cloud Scheduler invoker for ${var.name}"
+}
+
+resource "google_project_iam_member" "scheduler_invoker" {
+  project = var.project_id
+  role    = "roles/run.invoker"
+  member  = "serviceAccount:${google_service_account.scheduler.email}"
+}
+
+resource "google_cloud_run_v2_job" "this" {
+  project  = var.project_id
+  location = var.region
+  name     = var.name
+
+  template {
+    parallelism = var.job.parallelism
+    task_count  = var.job.completions
+
+    template {
+      service_account = google_service_account.runtime.email
+      timeout         = "${var.job.timeout_seconds}s"
+      max_retries     = var.job.max_retries
+
+      containers {
+        image = var.image
+        args  = var.args
+
+        resources {
+          limits = {
+            cpu    = tostring(var.resources.cpu)
+            memory = local.memory_quantity
+          }
+        }
+
+        dynamic "env" {
+          for_each = var.env
+          content {
+            name  = env.key
+            value = env.value
+          }
+        }
+
+        dynamic "env" {
+          for_each = var.secret_env
+          content {
+            name = env.key
+            value_source {
+              secret_key_ref {
+                secret  = env.value.secret
+                version = env.value.version
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "google_cloud_scheduler_job" "this" {
+  project   = var.project_id
+  region    = var.region
+  name      = "${var.name}-trigger"
+  schedule  = var.schedule.cron
+  time_zone = var.schedule.time_zone
+
+  attempt_deadline = try(var.cloud_scheduler.attempt_deadline_seconds, null) == null ? null : "${var.cloud_scheduler.attempt_deadline_seconds}s"
+
+  dynamic "retry_config" {
+    for_each = var.cloud_scheduler.retry_count > 0 ? [1] : []
+    content {
+      retry_count = var.cloud_scheduler.retry_count
+    }
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${var.name}:run"
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+    }
+  }
+}

--- a/devtools/bifrost/terraform/modules/cronjob_cloudrun/outputs.tf
+++ b/devtools/bifrost/terraform/modules/cronjob_cloudrun/outputs.tf
@@ -1,0 +1,14 @@
+output "service_account_email" {
+  value       = google_service_account.runtime.email
+  description = "Runtime GSA email for the Cloud Run Job. Grant IAM to this for GCP resource access."
+}
+
+output "scheduler_service_account_email" {
+  value       = google_service_account.scheduler.email
+  description = "Cloud Scheduler invoker GSA email."
+}
+
+output "job_id" {
+  value       = google_cloud_run_v2_job.this.id
+  description = "Cloud Run Job resource ID."
+}

--- a/devtools/bifrost/terraform/modules/cronjob_cloudrun/variables.tf
+++ b/devtools/bifrost/terraform/modules/cronjob_cloudrun/variables.tf
@@ -1,0 +1,85 @@
+variable "name" {
+  type        = string
+  description = "Cronjob name. Used for the Cloud Run Job, the scheduler job, and the derived GSA account_ids."
+}
+
+variable "project_id" {
+  type        = string
+  description = "GCP project that owns the Cloud Run Job, service accounts, and Secret Manager secrets."
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region for the Cloud Run Job and the Cloud Scheduler job."
+}
+
+variable "image" {
+  type        = string
+  description = "Container image, digest-pinned."
+  validation {
+    condition     = can(regex("@sha256:[0-9a-f]{64}$", var.image))
+    error_message = "image must be digest-pinned: <registry>/<repo>@sha256:<64-hex>"
+  }
+}
+
+variable "args" {
+  type        = list(string)
+  default     = []
+  description = "Container args."
+}
+
+variable "resources" {
+  type        = object({ cpu = number, memory = number })
+  description = "CPU in cores (float). Memory in MiB (int). Cloud Run Jobs size tasks from limits; both are enforced."
+}
+
+variable "env" {
+  type        = map(string)
+  default     = {}
+  description = "Plain environment variables."
+}
+
+variable "secret_env" {
+  type = map(object({
+    project = string
+    secret  = string
+    version = string
+  }))
+  default     = {}
+  description = "Secret env vars from GCP Secret Manager. Cloud Run references SM natively via secret_key_ref; version must be an explicit integer (\"latest\" is rejected)."
+  validation {
+    condition     = alltrue([for k, v in var.secret_env : v.version != "latest" && can(regex("^[0-9]+$", v.version))])
+    error_message = "secret_env[*].version must be an explicit integer; \"latest\" is forbidden."
+  }
+}
+
+variable "schedule" {
+  type        = object({ cron = string, time_zone = string })
+  description = "Cron spec for the Cloud Scheduler trigger."
+}
+
+variable "job" {
+  type = object({
+    parallelism     = optional(number, 1)
+    completions     = optional(number, 1)
+    max_retries     = optional(number, 3)
+    timeout_seconds = optional(number, 600)
+  })
+  default     = {}
+  description = "Cloud Run Job execution settings."
+}
+
+variable "cloud_scheduler" {
+  type = object({
+    retry_count              = optional(number, 0)
+    attempt_deadline_seconds = optional(number, null)
+  })
+  default     = {}
+  description = "Cloud Scheduler retry configuration."
+}
+
+variable "service_account_id" {
+  type        = string
+  default     = null
+  description = "GSA account_id for the runtime (Cloud Run Job) identity. Defaults to \"crj-<name>\"."
+}

--- a/devtools/bifrost/terraform/modules/cronjob_cloudrun/versions.tf
+++ b/devtools/bifrost/terraform/modules/cronjob_cloudrun/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.14.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+  }
+}

--- a/devtools/bifrost/terraform/modules/cronjob_kubernetes/BUILD
+++ b/devtools/bifrost/terraform/modules/cronjob_kubernetes/BUILD
@@ -1,0 +1,31 @@
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+_HCL_SRCS = glob(
+    ["**/*.tf"],
+    allow_empty = False,
+)
+
+filegroup(
+    name = "module",
+    srcs = _HCL_SRCS,
+    visibility = ["//visibility:public"],
+)
+
+# Lint, not a test. `terraform fmt -check -recursive` in the Bazel sandbox.
+# Semantic validation requires provider downloads (network) — see :validate
+# for the local-only target.
+sh_test(
+    name = "lint",
+    size = "small",
+    srcs = ["//devtools/bifrost/terraform/modules:fmt_check.sh"],
+    args = ["$(rootpath @multitool//tools/terraform)"],
+    data = _HCL_SRCS + ["@multitool//tools/terraform"],
+)
+
+sh_binary(
+    name = "validate",
+    srcs = ["//devtools/bifrost/terraform/modules:validate.sh"],
+    args = ["$(rootpath @multitool//tools/terraform)"],
+    data = _HCL_SRCS + ["@multitool//tools/terraform"],
+)

--- a/devtools/bifrost/terraform/modules/cronjob_kubernetes/README.md
+++ b/devtools/bifrost/terraform/modules/cronjob_kubernetes/README.md
@@ -1,0 +1,38 @@
+# `cronjob_kubernetes` Terraform module (PoC)
+
+A module for a Kubernetes CronJob with the same architectural shape as the `service` module: Terraform provisions the infrastructure shell via SSA, External Secrets Operator resolves secrets at runtime.
+
+> **Status:** proof of concept. See [`service_kubernetes/README.md`](../service_kubernetes/README.md) for the broader migration note.
+
+## What it creates
+
+- `google_service_account` + `google_service_account_iam_member` — runtime GSA + Workload Identity binding.
+- `kubernetes_manifest` / `ServiceAccount` — annotated for Workload Identity.
+- `kubernetes_secret_v1` (optional) — typed-resource carve-out for `ephemeral + data_wo`; see [`service_kubernetes/README.md`](../service_kubernetes/README.md#server-side-apply-with-one-carve-out) for the rationale.
+- `kubernetes_manifest` / `CronJob` — under SSA, `image` computed so push controllers can own it.
+
+## The Google resource standard (batch variant)
+
+CronJobs set **both** CPU and memory `requests == limits`. The web-serving "requests only on CPU" rule does not apply to batch:
+
+> A misbehaving batch job with no CPU limit can starve co-tenant web pods on the node.
+
+`resources = { cpu = 0.25, memory = 256 }` → `requests.cpu = limits.cpu = "250m"`, `requests.memory = limits.memory = "256Mi"`.
+
+## SSA + immutability
+
+Same model as `service`:
+
+- SSA via `kubernetes_manifest` + `field_manager { name = "terraform" }`.
+- `image` in `computed_fields` so push controllers own it on subsequent applies.
+- Secrets via `ephemeral + kubernetes_secret_v1.data_wo` (typed carve-out); content-hashed Secret name.
+- `image` digest-pinned; `secret_env[*].version` explicit integer (`"latest"` rejected).
+
+## Inputs / outputs / verification
+
+See [`variables.tf`](./variables.tf), [`outputs.tf`](./outputs.tf), and the `service` README for the verification workflow — the pattern is identical.
+
+```bash
+bazel test //devtools/bifrost/terraform/modules/cronjob_kubernetes:lint
+bazel run  //devtools/bifrost/terraform/modules/cronjob_kubernetes:validate
+```

--- a/devtools/bifrost/terraform/modules/cronjob_kubernetes/examples/basic/main.tf
+++ b/devtools/bifrost/terraform/modules/cronjob_kubernetes/examples/basic/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_version = ">= 1.14.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.38"
+    }
+  }
+}
+
+provider "google" {
+  project = "senku-prod"
+  region  = "europe-west1"
+}
+
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}
+
+module "cleanup" {
+  source = "../.."
+
+  name       = "cleanup"
+  project_id = "senku-prod"
+  namespace  = "jobs"
+
+  image     = "europe-docker.pkg.dev/senku-prod/jobs/cleanup@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+  resources = { cpu = 0.25, memory = 256 }
+
+  schedule = {
+    cron      = "0 2 * * *"
+    time_zone = "Europe/Madrid"
+  }
+
+  job = {
+    timeout_seconds = 1800
+  }
+}

--- a/devtools/bifrost/terraform/modules/cronjob_kubernetes/main.tf
+++ b/devtools/bifrost/terraform/modules/cronjob_kubernetes/main.tf
@@ -1,0 +1,182 @@
+locals {
+  runtime_sa_id   = coalesce(var.service_account_id, "crj-${var.name}")
+  labels          = merge({ "app.kubernetes.io/name" = var.name }, var.labels)
+  cpu_quantity    = "${floor(var.resources.cpu * 1000)}m"
+  memory_quantity = "${var.resources.memory}Mi"
+  field_manager   = "terraform"
+
+  # 13 hex chars = 52 bits: collision-safe and fits in float64 so the same
+  # value feeds data_wo_revision as an int.
+  secret_env_hash = length(var.secret_env) > 0 ? substr(sha256(jsonencode(var.secret_env)), 0, 13) : ""
+  secret_env_name = length(var.secret_env) > 0 ? "${var.name}-env-${local.secret_env_hash}" : ""
+
+  # Hardcoded "app" matches the Go renderer and keeps the container name
+  # stable across workloads (useful for any per-container policy refs).
+  container_name = "app"
+
+  container_security_context = {
+    runAsNonRoot             = true
+    allowPrivilegeEscalation = false
+    readOnlyRootFilesystem   = true
+    capabilities             = { drop = ["ALL"] }
+    seccompProfile           = { type = "RuntimeDefault" }
+  }
+
+  pod_security_context = {
+    runAsNonRoot   = true
+    seccompProfile = { type = "RuntimeDefault" }
+  }
+
+  container = merge(
+    {
+      name            = local.container_name
+      image           = var.image
+      args            = var.args
+      securityContext = local.container_security_context
+      # Batch gets BOTH CPU and memory request==limit. The "CPU request only"
+      # rule is a web-serving rule; a runaway batch job with no CPU limit
+      # would starve co-tenant pods on the node.
+      resources = {
+        requests = {
+          cpu    = local.cpu_quantity
+          memory = local.memory_quantity
+        }
+        limits = {
+          cpu    = local.cpu_quantity
+          memory = local.memory_quantity
+        }
+      }
+      env = [
+        for k, v in var.env : {
+          name  = k
+          value = v
+        }
+      ]
+    },
+    length(var.secret_env) > 0 ? {
+      envFrom = [{ secretRef = { name = local.secret_env_name } }]
+    } : {},
+  )
+}
+
+# ─── GCP identity ────────────────────────────────────────────────────────────
+
+resource "google_service_account" "runtime" {
+  project      = var.project_id
+  account_id   = local.runtime_sa_id
+  display_name = "Runtime identity for cronjob ${var.name}"
+}
+
+resource "google_service_account_iam_member" "workload_identity" {
+  service_account_id = google_service_account.runtime.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/${var.name}]"
+}
+
+# ─── Kubernetes via SSA ──────────────────────────────────────────────────────
+
+resource "kubernetes_manifest" "service_account" {
+  field_manager {
+    name            = local.field_manager
+    force_conflicts = true
+  }
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "ServiceAccount"
+    metadata = {
+      name        = var.name
+      namespace   = var.namespace
+      labels      = local.labels
+      annotations = { "iam.gke.io/gcp-service-account" = google_service_account.runtime.email }
+    }
+  }
+}
+
+ephemeral "google_secret_manager_secret_version" "env" {
+  for_each = var.secret_env
+  project  = each.value.project
+  secret   = each.value.secret
+  version  = each.value.version
+}
+
+# Typed-resource carve-out. See service_kubernetes/main.tf for the full rationale:
+# kubernetes_manifest doesn't yet expose write-only on its dynamic `manifest`
+# attribute, so ephemeral secret material can't flow through SSA. Single-
+# writer → losing SSA coordination here costs nothing.
+resource "kubernetes_secret_v1" "env" {
+  count = length(var.secret_env) > 0 ? 1 : 0
+
+  metadata {
+    name      = local.secret_env_name
+    namespace = var.namespace
+    labels    = local.labels
+  }
+
+  data_wo = {
+    for k, _ in var.secret_env :
+    k => ephemeral.google_secret_manager_secret_version.env[k].secret_data
+  }
+  # See service_kubernetes/main.tf for the non-monotonic revision rationale.
+  data_wo_revision = parseint(local.secret_env_hash, 16)
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "kubernetes_manifest" "cron_job" {
+  field_manager {
+    name            = local.field_manager
+    force_conflicts = false
+  }
+
+  # Image version is owned by the push controller (Flagger / Argo) on
+  # subsequent applies; Terraform provides the initial value.
+  computed_fields = [
+    "metadata.annotations",
+    "metadata.labels",
+    "spec.jobTemplate.spec.template.spec.containers[0].image",
+  ]
+
+  manifest = {
+    apiVersion = "batch/v1"
+    kind       = "CronJob"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+      labels    = local.labels
+    }
+    spec = {
+      schedule                   = var.schedule.cron
+      timeZone                   = var.schedule.time_zone
+      concurrencyPolicy          = "Forbid"
+      successfulJobsHistoryLimit = 3
+      failedJobsHistoryLimit     = 1
+      jobTemplate = {
+        metadata = { labels = local.labels }
+        spec = {
+          parallelism           = var.job.parallelism
+          completions           = var.job.completions
+          backoffLimit          = var.job.max_retries
+          activeDeadlineSeconds = var.job.timeout_seconds
+          template = {
+            metadata = { labels = local.labels }
+            spec = {
+              serviceAccountName = var.name
+              restartPolicy      = "Never"
+              securityContext    = local.pod_security_context
+              containers         = [local.container]
+            }
+          }
+        }
+      }
+    }
+  }
+
+  # See service_kubernetes/main.tf for why Secret is an explicit depends_on.
+  depends_on = [
+    kubernetes_manifest.service_account,
+    kubernetes_secret_v1.env,
+  ]
+}

--- a/devtools/bifrost/terraform/modules/cronjob_kubernetes/outputs.tf
+++ b/devtools/bifrost/terraform/modules/cronjob_kubernetes/outputs.tf
@@ -1,0 +1,14 @@
+output "service_account_email" {
+  value       = google_service_account.runtime.email
+  description = "Runtime GSA email. Grant IAM to this for GCP resource access from the job."
+}
+
+output "kubernetes_service_account_name" {
+  value       = kubernetes_manifest.service_account.manifest.metadata.name
+  description = "Kubernetes ServiceAccount name."
+}
+
+output "cron_job_name" {
+  value       = kubernetes_manifest.cron_job.manifest.metadata.name
+  description = "CronJob name."
+}

--- a/devtools/bifrost/terraform/modules/cronjob_kubernetes/variables.tf
+++ b/devtools/bifrost/terraform/modules/cronjob_kubernetes/variables.tf
@@ -1,0 +1,82 @@
+variable "name" {
+  type        = string
+  description = "CronJob name. Used for the K8s CronJob, ServiceAccount, and derived GSA account_id."
+}
+
+variable "project_id" {
+  type        = string
+  description = "GCP project that owns the runtime service account and Secret Manager secrets."
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace."
+}
+
+variable "image" {
+  type        = string
+  description = "Container image, digest-pinned."
+  validation {
+    condition     = can(regex("@sha256:[0-9a-f]{64}$", var.image))
+    error_message = "image must be digest-pinned: <registry>/<repo>@sha256:<64-hex>"
+  }
+}
+
+variable "args" {
+  type        = list(string)
+  default     = []
+  description = "Container args."
+}
+
+variable "resources" {
+  type        = object({ cpu = number, memory = number })
+  description = "CPU in cores (float). Memory in MiB (int). CronJobs set BOTH requests and limits on CPU and memory — the web-serving \"requests only\" rule does not apply to batch. A misbehaving batch job with no CPU limit will starve co-tenant web pods on the node."
+}
+
+variable "env" {
+  type        = map(string)
+  default     = {}
+  description = "Plain environment variables."
+}
+
+variable "secret_env" {
+  type = map(object({
+    project = string
+    secret  = string
+    version = string
+  }))
+  default     = {}
+  description = "Secret env vars from GCP Secret Manager via ephemeral + data_wo. Version must be an integer; \"latest\" is rejected — deploys are immutable and reference a specific SM version."
+  validation {
+    condition     = alltrue([for k, v in var.secret_env : v.version != "latest" && can(regex("^[0-9]+$", v.version))])
+    error_message = "secret_env[*].version must be an explicit integer; \"latest\" is forbidden."
+  }
+}
+
+variable "schedule" {
+  type        = object({ cron = string, time_zone = string })
+  description = "Cron spec: cron e.g. \"0 * * * *\"; time_zone e.g. \"Europe/Madrid\"."
+}
+
+variable "job" {
+  type = object({
+    parallelism     = optional(number, 1)
+    completions     = optional(number, 1)
+    max_retries     = optional(number, 3)
+    timeout_seconds = optional(number, 600)
+  })
+  default     = {}
+  description = "Job execution settings."
+}
+
+variable "service_account_id" {
+  type        = string
+  default     = null
+  description = "GSA account_id for the runtime identity. Defaults to \"crj-<name>\"."
+}
+
+variable "labels" {
+  type        = map(string)
+  default     = {}
+  description = "Labels applied to all K8s objects."
+}

--- a/devtools/bifrost/terraform/modules/cronjob_kubernetes/versions.tf
+++ b/devtools/bifrost/terraform/modules/cronjob_kubernetes/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.14.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.38"
+    }
+  }
+}

--- a/devtools/bifrost/terraform/modules/fmt_check.sh
+++ b/devtools/bifrost/terraform/modules/fmt_check.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Hermetic HCL format check. Runs `terraform fmt -check -recursive` against
+# every .tf file packaged as test data.
+#
+# Args: $1 = rootpath to the terraform binary (from @multitool//tools/terraform).
+#
+# Why only fmt: `terraform init` needs network to download providers and the
+# Bazel sandbox has none. `terraform validate` requires init. fmt is offline
+# and still catches HCL syntax errors.
+set -euo pipefail
+
+TERRAFORM="$PWD/$1"
+shift
+
+# Discover the module root — the directory containing this test's data tree.
+MODULE_ROOT=""
+for tf in "$TEST_SRCDIR"/_main/devtools/bifrost/terraform/modules/*/; do
+  # Match the module whose files are under this test's runfiles.
+  if compgen -G "${tf}*.tf" > /dev/null; then
+    MODULE_ROOT="$tf"
+    break
+  fi
+done
+
+if [[ -z "$MODULE_ROOT" ]]; then
+  # Fall back: find any directory with a .tf file and recurse from there.
+  MODULE_ROOT="$(find "$TEST_SRCDIR/_main/devtools/bifrost/terraform/modules" -name "*.tf" -printf "%h\n" | sort -u | head -n1)"
+fi
+
+echo "terraform fmt -check -recursive $MODULE_ROOT"
+"$TERRAFORM" fmt -check -recursive "$MODULE_ROOT"

--- a/devtools/bifrost/terraform/modules/service_cloudrun/BUILD
+++ b/devtools/bifrost/terraform/modules/service_cloudrun/BUILD
@@ -1,0 +1,29 @@
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+_HCL_SRCS = glob(
+    ["**/*.tf"],
+    allow_empty = False,
+)
+
+filegroup(
+    name = "module",
+    srcs = _HCL_SRCS,
+    visibility = ["//visibility:public"],
+)
+
+# Lint, not a test. `terraform fmt -check -recursive` in the Bazel sandbox.
+sh_test(
+    name = "lint",
+    size = "small",
+    srcs = ["//devtools/bifrost/terraform/modules:fmt_check.sh"],
+    args = ["$(rootpath @multitool//tools/terraform)"],
+    data = _HCL_SRCS + ["@multitool//tools/terraform"],
+)
+
+sh_binary(
+    name = "validate",
+    srcs = ["//devtools/bifrost/terraform/modules:validate.sh"],
+    args = ["$(rootpath @multitool//tools/terraform)"],
+    data = _HCL_SRCS + ["@multitool//tools/terraform"],
+)

--- a/devtools/bifrost/terraform/modules/service_cloudrun/README.md
+++ b/devtools/bifrost/terraform/modules/service_cloudrun/README.md
@@ -61,10 +61,23 @@ See [`variables.tf`](./variables.tf). Notable ones:
 - `startup_cpu_boost` — free cold-start speedup, default on.
 - `execution_environment` — `EXECUTION_ENVIRONMENT_GEN2` default (Linux cgroups); `GEN1` for legacy gVisor.
 
+## Custom domains
+
+`custom_domains = ["api.example.com", ...]` creates a `google_cloud_run_domain_mapping` per entry. Cloud Run provisions a managed TLS cert once DNS resolves to the returned records.
+
+Caveats inherited from the feature (pick a load balancer instead if any of these hurt):
+
+- Not available in every region. `europe-west1`, `us-central1`, `asia-northeast1`, and a few others are supported; `europe-west4`, `us-east4`, and others are not. See Google's docs for the current list.
+- The domain must be verified in the project's Search Console before `terraform apply` succeeds.
+- No CDN, no Cloud Armor, no multi-region fan-out, no sharing TLS across services.
+
+Output `custom_domain_dns_records` exposes the `{ type, name, rrdata }` tuples to create in your DNS provider.
+
 ## Outputs
 
 - `service_account_email` — runtime GSA; grant IAM on other resources.
 - `service_name`, `service_uri`, `service_id` — for DNS wiring, Cloud Scheduler targets, load balancer backends.
+- `custom_domain_dns_records` — DNS records to create per domain mapping.
 
 ## Verification
 

--- a/devtools/bifrost/terraform/modules/service_cloudrun/README.md
+++ b/devtools/bifrost/terraform/modules/service_cloudrun/README.md
@@ -1,0 +1,76 @@
+# `service_cloudrun` Terraform module (PoC)
+
+A module for a Cloud Run web service. Parallel to [`service_kubernetes`](../service_kubernetes/README.md), but targeting the managed serverless control plane instead of GKE.
+
+> **Status:** proof of concept.
+
+## Architecture — different from Kubernetes on purpose
+
+Cloud Run is not Kubernetes, and a lot of the K8s module's shape doesn't apply:
+
+| Concern | Kubernetes module | Cloud Run module |
+|---|---|---|
+| Rollout controller | Flagger / Argo Rollouts (external) | Cloud Run native (revisions + traffic allocation) |
+| Server-Side Apply | Yes (`kubernetes_manifest`) | N/A — this is the google provider calling GCP APIs |
+| HPA / VPA / PDB | Yes | No — Cloud Run's native scaling subsumes them |
+| Secret materialisation | `ephemeral + data_wo` + typed Secret carve-out | Native `secret_key_ref` — Cloud Run reads SM at container startup |
+| Pod security context | Hardened at the container level | N/A — every Cloud Run instance runs sandboxed (gVisor or Linux cgroups) |
+| Namespaces | Required | None — project + region scopes the service |
+
+Terraform owns everything for Cloud Run — there's no Flagger, no HPA, no `computed_fields` coordination. `terraform apply` with a new `var.image` creates a new revision; the default traffic policy (`TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST`, 100%) sends traffic immediately.
+
+## Resource contract
+
+`resources = { cpu, memory }` maps directly to Cloud Run's `limits`:
+
+- `cpu` in cores (float, e.g. `0.5`) → `"0.5"`
+- `memory` in MiB (int, e.g. `512`) → `"512Mi"`
+
+Cloud Run has no request/limit split. The "no CPU limit for web services" rule doesn't apply because each Cloud Run instance is isolated — there's no co-tenant on the same node to throttle.
+
+## Secrets
+
+`secret_env = map({ project, secret, version })` — same shape as the K8s module. Resolution differs: Cloud Run calls Secret Manager at container start and injects the value into the process environment. Nothing is materialised as a K8s Secret; nothing enters Terraform state.
+
+Version must be an explicit integer. `"latest"` is rejected — deploys are immutable, rotation is an explicit version bump that produces a new Cloud Run revision.
+
+## Image pinning
+
+`image` must be digest-pinned (`…@sha256:…`), validated.
+
+## Scaling
+
+`scaling = { min, max }` — Cloud Run allows `min = 0` (scale-to-zero), unlike HPA. The module's validation accepts that.
+
+`concurrency` sets max concurrent requests per instance. This is the native Cloud Run primitive and has no K8s equivalent.
+
+## Traffic / rollouts
+
+The module sets a single traffic block: `TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST` at 100%. That means every apply of a new image takes full traffic immediately. Canary traffic splits (e.g. 10% to new revision, 90% to prior) require revision names that only exist post-apply, so they're not exposed as a module input. Callers who want canaries either:
+
+1. Use Cloud Deploy / Cloud Deploy for Cloud Run (separate control plane, like Flagger for Cloud Run).
+2. Override the `google_cloud_run_v2_service.traffic` resource directly outside the module, pinning to named revisions.
+
+## Inputs
+
+See [`variables.tf`](./variables.tf). Notable ones:
+
+- `public` — when `true`, grants `roles/run.invoker` to `allUsers`. Default `false` (private by construction).
+- `ingress` — `INGRESS_TRAFFIC_ALL`, `INGRESS_TRAFFIC_INTERNAL_ONLY`, or `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER`.
+- `cpu_idle` — whether CPU is throttled outside requests. `true` (default) is cheaper; `false` keeps CPU allocated always.
+- `startup_cpu_boost` — free cold-start speedup, default on.
+- `execution_environment` — `EXECUTION_ENVIRONMENT_GEN2` default (Linux cgroups); `GEN1` for legacy gVisor.
+
+## Outputs
+
+- `service_account_email` — runtime GSA; grant IAM on other resources.
+- `service_name`, `service_uri`, `service_id` — for DNS wiring, Cloud Scheduler targets, load balancer backends.
+
+## Verification
+
+```bash
+bazel test //devtools/bifrost/terraform/modules/service_cloudrun:lint
+bazel run  //devtools/bifrost/terraform/modules/service_cloudrun:validate
+```
+
+Lint is `terraform fmt -check -recursive`; semantic validation needs provider downloads and runs locally only.

--- a/devtools/bifrost/terraform/modules/service_cloudrun/examples/basic/main.tf
+++ b/devtools/bifrost/terraform/modules/service_cloudrun/examples/basic/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_version = ">= 1.14.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+  }
+}
+
+provider "google" {
+  project = "senku-prod"
+  region  = "europe-west1"
+}
+
+module "hello" {
+  source = "../.."
+
+  name       = "hello"
+  project_id = "senku-prod"
+  region     = "europe-west1"
+
+  image     = "gcr.io/google-samples/hello-app@sha256:3f87c2db2eab75bf8e5a3a48d6be1f73bb2a0c1e7e34e08b3e7b7e3b7e3b7e3b"
+  resources = { cpu = 0.5, memory = 512 }
+
+  scaling = {
+    min = 0
+    max = 3
+  }
+
+  public = true
+}

--- a/devtools/bifrost/terraform/modules/service_cloudrun/examples/with_custom_domain/main.tf
+++ b/devtools/bifrost/terraform/modules/service_cloudrun/examples/with_custom_domain/main.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_version = ">= 1.14.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+  }
+}
+
+provider "google" {
+  project = "senku-prod"
+  region  = "europe-west1"
+}
+
+module "hello" {
+  source = "../.."
+
+  name       = "hello"
+  project_id = "senku-prod"
+  region     = "europe-west1"
+
+  image     = "gcr.io/google-samples/hello-app@sha256:3f87c2db2eab75bf8e5a3a48d6be1f73bb2a0c1e7e34e08b3e7b7e3b7e3b7e3b"
+  resources = { cpu = 0.5, memory = 512 }
+
+  scaling = {
+    min = 0
+    max = 3
+  }
+
+  public = true
+
+  custom_domains = [
+    "hello.senku.example.com",
+  ]
+}
+
+output "hello_dns_records" {
+  value = module.hello.custom_domain_dns_records
+}

--- a/devtools/bifrost/terraform/modules/service_cloudrun/main.tf
+++ b/devtools/bifrost/terraform/modules/service_cloudrun/main.tf
@@ -129,3 +129,22 @@ resource "google_cloud_run_v2_service_iam_member" "public" {
   role     = "roles/run.invoker"
   member   = "allUsers"
 }
+
+# Cloud Run domain mappings. The v1 API resource is what the google provider
+# exposes; it interoperates with v2 services by referencing the service name.
+# The parent project must have the domain verified in Search Console.
+resource "google_cloud_run_domain_mapping" "custom" {
+  for_each = toset(var.custom_domains)
+
+  name     = each.value
+  location = var.region
+
+  metadata {
+    namespace = var.project_id
+    labels    = local.labels
+  }
+
+  spec {
+    route_name = google_cloud_run_v2_service.this.name
+  }
+}

--- a/devtools/bifrost/terraform/modules/service_cloudrun/main.tf
+++ b/devtools/bifrost/terraform/modules/service_cloudrun/main.tf
@@ -1,0 +1,131 @@
+locals {
+  service_account_id = coalesce(var.service_account_id, "svc-${var.name}")
+  labels             = merge({ "app.kubernetes.io/name" = var.name }, var.labels)
+  cpu_quantity       = tostring(var.resources.cpu)
+  memory_quantity    = "${var.resources.memory}Mi"
+
+  plain_env = [
+    for k, v in var.env : {
+      name  = k
+      value = v
+    }
+  ]
+
+  secret_env = [
+    for k, v in var.secret_env : {
+      name = k
+      value_source = {
+        secret_key_ref = {
+          secret  = v.secret
+          version = v.version
+        }
+      }
+    }
+  ]
+}
+
+resource "google_service_account" "runtime" {
+  project      = var.project_id
+  account_id   = local.service_account_id
+  display_name = "Runtime identity for ${var.name}"
+}
+
+resource "google_cloud_run_v2_service" "this" {
+  project  = var.project_id
+  location = var.region
+  name     = var.name
+  ingress  = var.ingress
+  labels   = local.labels
+
+  template {
+    service_account                  = google_service_account.runtime.email
+    execution_environment            = var.execution_environment
+    max_instance_request_concurrency = var.concurrency
+    timeout                          = "${var.timeout_seconds}s"
+
+    scaling {
+      min_instance_count = var.scaling.min
+      max_instance_count = var.scaling.max
+    }
+
+    containers {
+      image = var.image
+      args  = var.args
+
+      ports {
+        container_port = var.port
+      }
+
+      resources {
+        limits = {
+          cpu    = local.cpu_quantity
+          memory = local.memory_quantity
+        }
+        cpu_idle          = var.cpu_idle
+        startup_cpu_boost = var.startup_cpu_boost
+      }
+
+      dynamic "env" {
+        for_each = local.plain_env
+        content {
+          name  = env.value.name
+          value = env.value.value
+        }
+      }
+
+      dynamic "env" {
+        for_each = local.secret_env
+        content {
+          name = env.value.name
+          value_source {
+            secret_key_ref {
+              secret  = env.value.value_source.secret_key_ref.secret
+              version = env.value.value_source.secret_key_ref.version
+            }
+          }
+        }
+      }
+
+      dynamic "startup_probe" {
+        for_each = try(var.probes.startup_path, null) == null ? [] : [var.probes.startup_path]
+        content {
+          http_get {
+            path = startup_probe.value
+            port = var.port
+          }
+        }
+      }
+
+      dynamic "liveness_probe" {
+        for_each = try(var.probes.liveness_path, null) == null ? [] : [var.probes.liveness_path]
+        content {
+          http_get {
+            path = liveness_probe.value
+            port = var.port
+          }
+        }
+      }
+    }
+  }
+
+  # Default traffic policy: latest revision takes 100%. Callers wanting
+  # canary traffic splits override this at the resource level by setting
+  # traffic blocks explicitly in a wrapper — not exposed as a module input
+  # because it requires revision names that only exist post-apply.
+  traffic {
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    percent = 100
+  }
+}
+
+# Grant public invoke access when var.public = true. Otherwise the service
+# is callable only by identities holding roles/run.invoker via other means.
+resource "google_cloud_run_v2_service_iam_member" "public" {
+  count = var.public ? 1 : 0
+
+  project  = var.project_id
+  location = google_cloud_run_v2_service.this.location
+  name     = google_cloud_run_v2_service.this.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/devtools/bifrost/terraform/modules/service_cloudrun/outputs.tf
+++ b/devtools/bifrost/terraform/modules/service_cloudrun/outputs.tf
@@ -1,0 +1,19 @@
+output "service_account_email" {
+  value       = google_service_account.runtime.email
+  description = "Runtime GSA email. Grant IAM on other resources (DBs, Redis, Secret Manager secrets) to this."
+}
+
+output "service_name" {
+  value       = google_cloud_run_v2_service.this.name
+  description = "Cloud Run service name."
+}
+
+output "service_uri" {
+  value       = google_cloud_run_v2_service.this.uri
+  description = "Canonical HTTPS URL Cloud Run assigned to this service. Useful for wiring a Cloud Scheduler / Cloud Tasks target or a load balancer backend."
+}
+
+output "service_id" {
+  value       = google_cloud_run_v2_service.this.id
+  description = "Full GCP resource ID. Use for IAM bindings from other Terraform."
+}

--- a/devtools/bifrost/terraform/modules/service_cloudrun/outputs.tf
+++ b/devtools/bifrost/terraform/modules/service_cloudrun/outputs.tf
@@ -17,3 +17,8 @@ output "service_id" {
   value       = google_cloud_run_v2_service.this.id
   description = "Full GCP resource ID. Use for IAM bindings from other Terraform."
 }
+
+output "custom_domain_dns_records" {
+  value       = { for d, m in google_cloud_run_domain_mapping.custom : d => m.status[0].resource_records }
+  description = "DNS records (type, name, rrdata) Cloud Run expects for each custom domain. Create these in your DNS provider to finish the mapping — Google won't serve traffic on the domain until they resolve."
+}

--- a/devtools/bifrost/terraform/modules/service_cloudrun/variables.tf
+++ b/devtools/bifrost/terraform/modules/service_cloudrun/variables.tf
@@ -141,3 +141,9 @@ variable "labels" {
   default     = {}
   description = "Labels applied to the Cloud Run service."
 }
+
+variable "custom_domains" {
+  type        = list(string)
+  default     = []
+  description = "Fully-qualified domains to attach via Cloud Run domain mappings. Only available in a subset of regions (see Google Cloud docs). Each mapping exposes DNS records via the `custom_domain_dns_records` output; the domain must be verified in the project's Search Console before apply succeeds."
+}

--- a/devtools/bifrost/terraform/modules/service_cloudrun/variables.tf
+++ b/devtools/bifrost/terraform/modules/service_cloudrun/variables.tf
@@ -1,0 +1,143 @@
+variable "name" {
+  type        = string
+  description = "Cloud Run service name. Used for the service, the derived runtime GSA account_id, and the revision name prefix."
+}
+
+variable "project_id" {
+  type        = string
+  description = "GCP project that owns the Cloud Run service, GSA, and Secret Manager secrets."
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region for the Cloud Run service."
+}
+
+variable "image" {
+  type        = string
+  description = "Container image, digest-pinned."
+  validation {
+    condition     = can(regex("@sha256:[0-9a-f]{64}$", var.image))
+    error_message = "image must be digest-pinned: <registry>/<repo>@sha256:<64-hex>"
+  }
+}
+
+variable "port" {
+  type        = number
+  default     = 8080
+  description = "Container port exposed to the Cloud Run front-end."
+}
+
+variable "args" {
+  type        = list(string)
+  default     = []
+  description = "Container args. Image entrypoint is preserved."
+}
+
+variable "resources" {
+  type        = object({ cpu = number, memory = number })
+  description = "CPU in cores (float, e.g. 0.5). Memory in MiB (int, e.g. 512). Cloud Run uses these as limits; there is no request/limit split in Cloud Run's model."
+}
+
+variable "env" {
+  type        = map(string)
+  default     = {}
+  description = "Plain environment variables."
+}
+
+variable "secret_env" {
+  type = map(object({
+    project = string
+    secret  = string
+    version = string
+  }))
+  default     = {}
+  description = "Secret env vars from GCP Secret Manager, resolved natively by Cloud Run via secret_key_ref at startup. Version must be an explicit integer; \"latest\" is rejected (immutability). No ephemeral/data_wo needed — Cloud Run never materialises a K8s Secret."
+  validation {
+    condition     = alltrue([for k, v in var.secret_env : v.version != "latest" && can(regex("^[0-9]+$", v.version))])
+    error_message = "secret_env[*].version must be an explicit integer; \"latest\" is forbidden."
+  }
+}
+
+variable "scaling" {
+  type = object({
+    min = number
+    max = number
+  })
+  description = "Instance scaling bounds. Cloud Run allows min = 0 (scale-to-zero); max must be >= min."
+  validation {
+    condition     = var.scaling.min >= 0 && var.scaling.max >= var.scaling.min
+    error_message = "scaling.min must be >= 0 and scaling.max must be >= scaling.min."
+  }
+}
+
+variable "concurrency" {
+  type        = number
+  default     = 80
+  description = "Max concurrent requests per instance. Cloud Run's native primitive for load-per-instance; there's no K8s equivalent."
+}
+
+variable "timeout_seconds" {
+  type        = number
+  default     = 300
+  description = "Request timeout. Cloud Run kills the request — not the instance — on expiry."
+}
+
+variable "probes" {
+  type = object({
+    startup_path  = optional(string)
+    liveness_path = optional(string)
+  })
+  default     = {}
+  description = "HTTP GET probe paths. Cloud Run doesn't have a readiness concept (it routes by health, not by readiness)."
+}
+
+variable "ingress" {
+  type        = string
+  default     = "INGRESS_TRAFFIC_ALL"
+  description = "Who can reach the Cloud Run URL. Valid: INGRESS_TRAFFIC_ALL, INGRESS_TRAFFIC_INTERNAL_ONLY, INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER."
+  validation {
+    condition     = contains(["INGRESS_TRAFFIC_ALL", "INGRESS_TRAFFIC_INTERNAL_ONLY", "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"], var.ingress)
+    error_message = "ingress must be INGRESS_TRAFFIC_ALL, INGRESS_TRAFFIC_INTERNAL_ONLY, or INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER."
+  }
+}
+
+variable "public" {
+  type        = bool
+  default     = false
+  description = "When true, grant roles/run.invoker to allUsers. Combined with ingress = INGRESS_TRAFFIC_ALL this makes the service publicly callable without auth. Defaults off — private by construction."
+}
+
+variable "cpu_idle" {
+  type        = bool
+  default     = true
+  description = "Whether CPU is throttled outside requests. true = cheaper (CPU allocated only during requests), default; false = CPU always allocated (faster cold starts for background work, more expensive)."
+}
+
+variable "startup_cpu_boost" {
+  type        = bool
+  default     = true
+  description = "Extra CPU during container startup to reduce cold-start latency. Costs nothing extra."
+}
+
+variable "execution_environment" {
+  type        = string
+  default     = "EXECUTION_ENVIRONMENT_GEN2"
+  description = "Cloud Run execution environment. GEN2 gives Linux cgroups and more realistic Linux semantics; GEN1 is the legacy gVisor sandbox."
+  validation {
+    condition     = contains(["EXECUTION_ENVIRONMENT_GEN1", "EXECUTION_ENVIRONMENT_GEN2"], var.execution_environment)
+    error_message = "execution_environment must be EXECUTION_ENVIRONMENT_GEN1 or EXECUTION_ENVIRONMENT_GEN2."
+  }
+}
+
+variable "service_account_id" {
+  type        = string
+  default     = null
+  description = "GSA account_id for the runtime identity. Defaults to \"svc-<name>\"."
+}
+
+variable "labels" {
+  type        = map(string)
+  default     = {}
+  description = "Labels applied to the Cloud Run service."
+}

--- a/devtools/bifrost/terraform/modules/service_cloudrun/versions.tf
+++ b/devtools/bifrost/terraform/modules/service_cloudrun/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.14.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+  }
+}

--- a/devtools/bifrost/terraform/modules/service_kubernetes/BUILD
+++ b/devtools/bifrost/terraform/modules/service_kubernetes/BUILD
@@ -1,0 +1,31 @@
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+_HCL_SRCS = glob(
+    ["**/*.tf"],
+    allow_empty = False,
+)
+
+filegroup(
+    name = "module",
+    srcs = _HCL_SRCS,
+    visibility = ["//visibility:public"],
+)
+
+# Lint, not a test. `terraform fmt -check -recursive` in the Bazel sandbox.
+# Semantic validation requires provider downloads (network) — see :validate
+# for the local-only target.
+sh_test(
+    name = "lint",
+    size = "small",
+    srcs = ["//devtools/bifrost/terraform/modules:fmt_check.sh"],
+    args = ["$(rootpath @multitool//tools/terraform)"],
+    data = _HCL_SRCS + ["@multitool//tools/terraform"],
+)
+
+sh_binary(
+    name = "validate",
+    srcs = ["//devtools/bifrost/terraform/modules:validate.sh"],
+    args = ["$(rootpath @multitool//tools/terraform)"],
+    data = _HCL_SRCS + ["@multitool//tools/terraform"],
+)

--- a/devtools/bifrost/terraform/modules/service_kubernetes/README.md
+++ b/devtools/bifrost/terraform/modules/service_kubernetes/README.md
@@ -1,0 +1,88 @@
+# `service_kubernetes` Terraform module (PoC)
+
+A module for a Kubernetes web service, shaped for a **TF-as-provisioner + Flagger-as-pusher** architecture.
+
+> **Status:** proof of concept. No caller yet. The Go-generated `*.generated.tf` path remains the source of truth for production workloads.
+
+## Architecture (the boundary)
+
+| Concern | Owner | Tool |
+|---|---|---|
+| GCP identity (GSA, Workload Identity binding) | Terraform | `google_*` |
+| Deployment spec (image, env, resources, probes) | Terraform | `kubernetes_manifest` via **SSA** |
+| Service, HPA, PDB, VPA (recommender) | Terraform | `kubernetes_manifest` via **SSA** |
+| Secret materialisation | Terraform (typed carve-out — see below) | `kubernetes_secret_v1 + ephemeral + data_wo` |
+| `spec.replicas` on the Deployment | HPA (steady state) + Flagger (briefly during canary) | — |
+| Canary rollout, traffic split, rollback on SLO breach | Flagger | sibling resources it owns |
+| Cross-resource wiring (`env.DB_HOST = module.db.hostname`, `depends_on`) | Terraform | HCL |
+
+Flagger **does not write back** to your Deployment. It watches it for spec changes (new image, new env), and on a change it creates/updates a sibling `-primary` Deployment plus shadow services, splits traffic, and promotes by copying your Deployment's spec into `-primary`. So `terraform apply` with a new `var.image` is what triggers a canary.
+
+## Server-Side Apply (with one carve-out)
+
+Every Kubernetes object is created via `kubernetes_manifest` with `field_manager { name = "terraform" }`. The Deployment yields ownership of `spec.replicas` via `computed_fields` — HPA owns it long-term, Flagger touches it briefly during canaries. The container `image` is **not** in `computed_fields`: Flagger doesn't write to the target Deployment, so Terraform owns image normally.
+
+**The one typed-resource exception is `kubernetes_secret_v1`.** Reason: `kubernetes_manifest` doesn't expose write-only on its dynamic `manifest` attribute, and ephemeral values can only flow into write-only destinations. The `hashicorp/kubernetes` provider hasn't shipped a `manifest_wo` sidecar or per-path write-only annotations yet. Since the Secret is single-writer (only this module touches it), losing SSA coordination on that one object costs nothing. When the provider gains write-only manifest support, the resource flips with a one-line change.
+
+**Cost of SSA:** `terraform plan` opens a connection to the apiserver to dry-run each manifest against the live schema. Plans fail on an unreachable cluster. This is the tradeoff you get for explicit multi-writer coordination.
+
+## PushOps / MPM-style immutability
+
+- `image` must be digest-pinned (`…@sha256:…`); validated.
+- `secret_env[*].version` must be an explicit integer; `"latest"` is rejected.
+- The K8s Secret name is content-hashed: `${name}-env-${sha256(secret_env)[:8]}`. Any change to `secret_env` produces a new Secret object and a new ReplicaSet. Rollback = revert the inputs; the hash names back to its prior value.
+
+## Secrets: ephemeral + write-only
+
+Values flow `GCP Secret Manager → ephemeral "google_secret_manager_secret_version" → kubernetes_secret_v1.data_wo`. The `ephemeral` block reads at apply time only; the value never enters Terraform state. The `data_wo` attribute writes into K8s but is never read back — also never in state. Rotation = bump `version` on the input; the hash changes; the Secret's name changes; a new Secret is created; a new ReplicaSet rolls out.
+
+No cluster prerequisites beyond a reachable apiserver.
+
+## The Google resource standard (web-serving variant)
+
+- `requests.cpu` only — no `limits.cpu` (avoid CFS throttling on latency-sensitive code).
+- `requests.memory == limits.memory` — memory is not burstable.
+
+`resources = { cpu = 0.25, memory = 512 }` → `requests.cpu = "250m"`, `requests.memory = limits.memory = "512Mi"`.
+
+CronJobs use the batch variant (both CPU and memory request==limit); see `cronjob_kubernetes/README.md`.
+
+## Composition
+
+See [`examples/with_db/main.tf`](./examples/with_db/main.tf):
+
+- `env = { DB_HOST = google_sql_database_instance.api.private_ip_address }` — DB hostname wired through plain HCL.
+- `depends_on = [kubernetes_job_v1.migrate]` — migration Job runs before the Deployment is created. Name the Job with the image digest if you want per-version migrations.
+- `google_secret_manager_secret_iam_member` granting the module's GSA access to each secret.
+
+## Inputs
+
+See [`variables.tf`](./variables.tf). Key ones:
+
+- `image` — digest-pinned; validated.
+- `resources = { cpu = float, memory = int }` — cores and MiB.
+- `secret_env = map({ project, secret, version })` — SM references; `"latest"` rejected.
+- `autoscaling = { min, max, target_cpu_utilization }` — `min >= 1` enforced (no silent clamp).
+- `probes = { startup_path, liveness_path, readiness_path }` — all optional; readiness is how a pod signals "not ready for traffic right now" during graceful shutdown or slow warmups.
+- `vpa_enabled` — default `true`. Emits a VPA in recommender-only mode (`updateMode = "Off"`): observes actual usage, surfaces recommendations on the VPA's status, never auto-mutates pods. Requires the VPA CRD in the cluster; set `false` if unavailable.
+
+A `PodDisruptionBudget` is emitted automatically when `autoscaling.min >= 2` (`maxUnavailable = 1`). On a single-replica service a PDB is pointless; on `min == max == 1` it blocks all voluntary disruption.
+
+## Outputs
+
+- `service_account_email` — the runtime GSA; grant IAM to this on DBs, buckets, secrets.
+- `kubernetes_service_account_name`, `deployment_name`, `service_name`.
+
+## Verification
+
+```bash
+bazel test //devtools/bifrost/terraform/modules/service_kubernetes:lint
+```
+
+`:lint` runs `terraform fmt -check -recursive` in the Bazel sandbox (offline). It's a linter, not a semantic test. Full validation needs provider downloads (network):
+
+```bash
+bazel run //devtools/bifrost/terraform/modules/service_kubernetes:validate
+```
+
+True semantic correctness — does SSA ownership split work as designed, does `data_wo` behave as expected under drift — is only verifiable by applying against a real cluster.

--- a/devtools/bifrost/terraform/modules/service_kubernetes/examples/basic/main.tf
+++ b/devtools/bifrost/terraform/modules/service_kubernetes/examples/basic/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_version = ">= 1.14.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.38"
+    }
+  }
+}
+
+provider "google" {
+  project = "senku-prod"
+  region  = "europe-west1"
+}
+
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}
+
+module "hello" {
+  source = "../.."
+
+  name       = "hello"
+  namespace  = "default"
+  project_id = "senku-prod"
+  image      = "gcr.io/google-samples/hello-app@sha256:3f87c2db2eab75bf8e5a3a48d6be1f73bb2a0c1e7e34e08b3e7b7e3b7e3b7e3b"
+  resources  = { cpu = 0.25, memory = 512 }
+
+  autoscaling = {
+    min = 1
+    max = 3
+  }
+}

--- a/devtools/bifrost/terraform/modules/service_kubernetes/examples/with_db/main.tf
+++ b/devtools/bifrost/terraform/modules/service_kubernetes/examples/with_db/main.tf
@@ -1,0 +1,122 @@
+# Demonstrates composition: a Cloud SQL instance provides the hostname for the
+# service's env, a Secret Manager secret holds the DB password, and a migration
+# Job must complete before the Deployment rolls out.
+
+terraform {
+  required_version = ">= 1.14.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.38"
+    }
+  }
+}
+
+provider "google" {
+  project = "senku-prod"
+  region  = "europe-west1"
+}
+
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}
+
+resource "google_sql_database_instance" "api" {
+  name             = "api-db"
+  database_version = "POSTGRES_16"
+  region           = "europe-west1"
+
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+      ipv4_enabled    = false
+      private_network = "projects/senku-prod/global/networks/default"
+    }
+  }
+  deletion_protection = true
+}
+
+resource "google_secret_manager_secret" "db_password" {
+  secret_id = "api-db-password"
+  replication {
+    auto {}
+  }
+}
+
+resource "kubernetes_job_v1" "migrate" {
+  metadata {
+    name      = "api-migrate"
+    namespace = "default"
+  }
+
+  spec {
+    backoff_limit = 0
+    template {
+      metadata {
+        labels = { "app.kubernetes.io/name" = "api-migrate" }
+      }
+      spec {
+        restart_policy = "Never"
+        container {
+          name  = "migrate"
+          image = "europe-docker.pkg.dev/senku-prod/api/migrate@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+          env {
+            name  = "DB_HOST"
+            value = google_sql_database_instance.api.private_ip_address
+          }
+        }
+      }
+    }
+  }
+
+  wait_for_completion = true
+}
+
+module "api" {
+  source = "../.."
+
+  name       = "api"
+  namespace  = "default"
+  project_id = "senku-prod"
+  image      = "europe-docker.pkg.dev/senku-prod/api/api@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+  port       = 8080
+  resources  = { cpu = 0.25, memory = 512 }
+
+  env = {
+    DB_HOST = google_sql_database_instance.api.private_ip_address
+    DB_NAME = "api"
+  }
+
+  secret_env = {
+    DB_PASSWORD = {
+      project = "senku-prod"
+      secret  = google_secret_manager_secret.db_password.secret_id
+      version = "3"
+    }
+  }
+
+  autoscaling = {
+    min = 1
+    max = 5
+  }
+
+  probes = {
+    startup_path   = "/healthz"
+    liveness_path  = "/healthz"
+    readiness_path = "/ready"
+  }
+
+  depends_on = [kubernetes_job_v1.migrate]
+}
+
+# Grant the service account access to the DB password secret.
+resource "google_secret_manager_secret_iam_member" "api_db_password" {
+  secret_id = google_secret_manager_secret.db_password.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${module.api.service_account_email}"
+}

--- a/devtools/bifrost/terraform/modules/service_kubernetes/main.tf
+++ b/devtools/bifrost/terraform/modules/service_kubernetes/main.tf
@@ -1,0 +1,354 @@
+locals {
+  service_account_id = coalesce(var.service_account_id, "svc-${var.name}")
+  gsa_email          = "${local.service_account_id}@${var.project_id}.iam.gserviceaccount.com"
+  labels             = merge({ "app.kubernetes.io/name" = var.name }, var.labels)
+  selector_labels    = { "app.kubernetes.io/name" = var.name }
+  cpu_request        = "${floor(var.resources.cpu * 1000)}m"
+  memory_quantity    = "${var.resources.memory}Mi"
+  field_manager      = "terraform"
+
+  # PushOps/MPM-style immutable naming: the Secret's name carries a content
+  # hash, so any change to var.secret_env produces a new Secret object and a
+  # new ReplicaSet. Rollback = revert the inputs, name hashes back to the
+  # prior value, Secret is re-materialised from Secret Manager.
+  #
+  # 13 hex chars = 52 bits: collision-safe at scale (~1 in 4.5 quadrillion
+  # per pair) AND fits in Terraform's float64 number type so the same value
+  # can feed data_wo_revision as an int.
+  secret_env_hash = length(var.secret_env) > 0 ? substr(sha256(jsonencode(var.secret_env)), 0, 13) : ""
+  secret_env_name = length(var.secret_env) > 0 ? "${var.name}-env-${local.secret_env_hash}" : ""
+
+  # Container is named "app" regardless of workload name so VPA
+  # resourcePolicy can target it by a stable name.
+  container_name = "app"
+
+  # Hardened security context applied to every container. Mirrors the Go
+  # renderer's defaults — restrictive by construction, not opt-in.
+  container_security_context = {
+    runAsNonRoot             = true
+    allowPrivilegeEscalation = false
+    readOnlyRootFilesystem   = true
+    capabilities             = { drop = ["ALL"] }
+    seccompProfile           = { type = "RuntimeDefault" }
+  }
+
+  pod_security_context = {
+    runAsNonRoot   = true
+    seccompProfile = { type = "RuntimeDefault" }
+  }
+
+  # Container spec is assembled via merge so optional fields (envFrom, probes)
+  # only appear when set — kubernetes_manifest rejects null fields.
+  container = merge(
+    {
+      name            = local.container_name
+      image           = var.image
+      args            = var.args
+      ports           = [{ containerPort = var.port }]
+      securityContext = local.container_security_context
+      env = [
+        for k, v in merge({ PORT = tostring(var.port) }, var.env) : {
+          name  = k
+          value = v
+        }
+      ]
+      resources = {
+        requests = {
+          cpu    = local.cpu_request
+          memory = local.memory_quantity
+        }
+        limits = {
+          memory = local.memory_quantity
+        }
+      }
+    },
+    length(var.secret_env) > 0 ? {
+      envFrom = [{ secretRef = { name = local.secret_env_name } }]
+    } : {},
+    try(var.probes.startup_path, null) != null ? {
+      startupProbe = { httpGet = { path = var.probes.startup_path, port = var.port } }
+    } : {},
+    try(var.probes.liveness_path, null) != null ? {
+      livenessProbe = { httpGet = { path = var.probes.liveness_path, port = var.port } }
+    } : {},
+    try(var.probes.readiness_path, null) != null ? {
+      readinessProbe = { httpGet = { path = var.probes.readiness_path, port = var.port } }
+    } : {},
+  )
+
+  pdb_enabled = var.autoscaling.min >= 2
+}
+
+# ─── GCP identity (google provider, no SSA concern) ──────────────────────────
+
+resource "google_service_account" "runtime" {
+  project      = var.project_id
+  account_id   = local.service_account_id
+  display_name = "Runtime identity for ${var.name}"
+}
+
+resource "google_service_account_iam_member" "workload_identity" {
+  service_account_id = google_service_account.runtime.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/${var.name}]"
+}
+
+# ─── Kubernetes objects via Server-Side Apply ────────────────────────────────
+#
+# Field-manager coordination:
+#   • "terraform" (this module) owns everything it declares.
+#   • Flagger / Argo Rollouts owns spec.replicas and the container image
+#     during rollout. Those fields are listed in computed_fields so Terraform
+#     does not send them under its field manager after initial creation and
+#     therefore does not fight the rollout controller.
+#
+# SSA cost: `terraform plan` opens a connection to the apiserver to dry-run
+# each manifest against the live schema. Plans fail on an unreachable cluster.
+
+resource "kubernetes_manifest" "service_account" {
+  field_manager {
+    name            = local.field_manager
+    force_conflicts = true
+  }
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "ServiceAccount"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+      labels    = local.labels
+      annotations = {
+        "iam.gke.io/gcp-service-account" = google_service_account.runtime.email
+      }
+    }
+  }
+}
+
+ephemeral "google_secret_manager_secret_version" "env" {
+  for_each = var.secret_env
+  project  = each.value.project
+  secret   = each.value.secret
+  version  = each.value.version
+}
+
+# Typed-resource carve-out. Every other K8s object in this module flows
+# through kubernetes_manifest under SSA; this one doesn't. Reason:
+# kubernetes_manifest does not expose write-only on its dynamic `manifest`
+# attribute, and ephemeral values cannot flow into a non-write-only
+# destination. The hashicorp/kubernetes provider hasn't shipped a
+# `manifest_wo` sidecar or per-path write-only annotations yet.
+#
+# Practical cost: the Secret is client-side applied rather than SSA. Since
+# only this module writes to it (single-writer), losing SSA coordination
+# here costs nothing. When the provider gains write-only manifest support,
+# flip this resource to kubernetes_manifest with the ephemeral value routed
+# to the write-only surface. Tracking: hashicorp/terraform-provider-kubernetes.
+resource "kubernetes_secret_v1" "env" {
+  count = length(var.secret_env) > 0 ? 1 : 0
+
+  metadata {
+    name      = local.secret_env_name
+    namespace = var.namespace
+    labels    = local.labels
+  }
+
+  data_wo = {
+    for k, _ in var.secret_env :
+    k => ephemeral.google_secret_manager_secret_version.env[k].secret_data
+  }
+  # Same content hash used in metadata.name, re-parsed as an int. The
+  # provider compares revision by inequality (!= prior), not strict
+  # monotonic (> prior), so a content change producing a numerically
+  # smaller int is fine. If a future provider version enforces strict
+  # monotonicity, flip this to a time_static-backed source.
+  data_wo_revision = parseint(local.secret_env_hash, 16)
+
+  # Replacement happens when local.secret_env_name (the hash-suffixed
+  # metadata.name) changes. create_before_destroy ensures the new Secret
+  # exists before the old one is deleted, so pod restarts during rollout
+  # can still mount the Secret their Deployment references.
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "kubernetes_manifest" "deployment" {
+  field_manager {
+    name            = local.field_manager
+    force_conflicts = false
+  }
+
+  # spec.replicas is owned by HPA long-term and briefly by Flagger during
+  # canary rollouts — excluded from drift detection here. The container
+  # image is NOT in computed_fields: Flagger watches the Deployment for
+  # spec changes but does not write back to it (it mutates its own
+  # `-primary` sibling on promotion). So Terraform owns `image` normally;
+  # `terraform apply` with a new var.image is what triggers a canary.
+  computed_fields = [
+    "metadata.annotations",
+    "metadata.labels",
+    "spec.replicas",
+  ]
+
+  manifest = {
+    apiVersion = "apps/v1"
+    kind       = "Deployment"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+      labels    = local.labels
+    }
+    spec = {
+      selector = { matchLabels = local.selector_labels }
+      template = {
+        metadata = { labels = local.labels }
+        spec = {
+          serviceAccountName = var.name
+          securityContext    = local.pod_security_context
+          containers         = [local.container]
+        }
+      }
+    }
+  }
+
+  # Explicit dependency on the Secret: the Deployment's envFrom references
+  # local.secret_env_name, which is a static expression (not a resource
+  # reference), so TF can't infer this ordering. Without it, the Deployment
+  # update and Secret create/replace can run in either order, and pods
+  # reaching the apiserver between steps see a stale or missing Secret.
+  depends_on = [
+    kubernetes_manifest.service_account,
+    kubernetes_secret_v1.env,
+  ]
+}
+
+resource "kubernetes_manifest" "service" {
+  field_manager {
+    name            = local.field_manager
+    force_conflicts = true
+  }
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+      labels    = local.labels
+    }
+    spec = {
+      type     = "ClusterIP"
+      selector = local.selector_labels
+      ports = [{
+        name       = "http"
+        port       = var.port
+        targetPort = var.port
+      }]
+    }
+  }
+}
+
+resource "kubernetes_manifest" "hpa" {
+  field_manager {
+    name            = local.field_manager
+    force_conflicts = true
+  }
+
+  manifest = {
+    apiVersion = "autoscaling/v2"
+    kind       = "HorizontalPodAutoscaler"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+      labels    = local.labels
+    }
+    spec = {
+      minReplicas = var.autoscaling.min
+      maxReplicas = var.autoscaling.max
+      scaleTargetRef = {
+        apiVersion = "apps/v1"
+        kind       = "Deployment"
+        name       = var.name
+      }
+      metrics = [{
+        type = "Resource"
+        resource = {
+          name = "cpu"
+          target = {
+            type               = "Utilization"
+            averageUtilization = var.autoscaling.target_cpu_utilization
+          }
+        }
+      }]
+    }
+  }
+
+  depends_on = [kubernetes_manifest.deployment]
+}
+
+# Only created when min_replicas >= 2: a PDB with min=max=1 is degenerate
+# (blocks all voluntary disruption) and a PDB on a single replica is
+# pointless (no alternative pod to preserve during drain).
+resource "kubernetes_manifest" "pdb" {
+  count = local.pdb_enabled ? 1 : 0
+
+  field_manager {
+    name            = local.field_manager
+    force_conflicts = true
+  }
+
+  manifest = {
+    apiVersion = "policy/v1"
+    kind       = "PodDisruptionBudget"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+      labels    = local.labels
+    }
+    spec = {
+      maxUnavailable = 1
+      selector       = { matchLabels = local.selector_labels }
+    }
+  }
+}
+
+# VPA in InPlaceOrRecreate mode, scoped to memory on the "app" container:
+# VPA actively resizes memory at runtime. CPU is deliberately excluded —
+# the Google standard sets only requests.cpu on web services and VPA-tuning
+# CPU would fight the "no CPU limit" shape. Requires the VPA CRD in the
+# cluster; `terraform plan` fails otherwise. Disable via var.vpa_enabled.
+resource "kubernetes_manifest" "vpa" {
+  count = var.vpa_enabled ? 1 : 0
+
+  field_manager {
+    name            = local.field_manager
+    force_conflicts = true
+  }
+
+  manifest = {
+    apiVersion = "autoscaling.k8s.io/v1"
+    kind       = "VerticalPodAutoscaler"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+      labels    = local.labels
+    }
+    spec = {
+      targetRef = {
+        apiVersion = "apps/v1"
+        kind       = "Deployment"
+        name       = var.name
+      }
+      updatePolicy = { updateMode = "InPlaceOrRecreate" }
+      resourcePolicy = {
+        containerPolicies = [{
+          containerName       = local.container_name
+          controlledResources = ["memory"]
+        }]
+      }
+    }
+  }
+
+  depends_on = [kubernetes_manifest.deployment]
+}

--- a/devtools/bifrost/terraform/modules/service_kubernetes/outputs.tf
+++ b/devtools/bifrost/terraform/modules/service_kubernetes/outputs.tf
@@ -1,0 +1,19 @@
+output "service_account_email" {
+  value       = google_service_account.runtime.email
+  description = "GSA email for the runtime identity. Grant IAM on other resources (DB, Redis, buckets) to this."
+}
+
+output "kubernetes_service_account_name" {
+  value       = kubernetes_manifest.service_account.manifest.metadata.name
+  description = "Kubernetes ServiceAccount name."
+}
+
+output "deployment_name" {
+  value       = kubernetes_manifest.deployment.manifest.metadata.name
+  description = "Deployment name. Consumers: Flagger Canary.spec.targetRef, HPA ScaleTargetRef wiring from external tools."
+}
+
+output "service_name" {
+  value       = kubernetes_manifest.service.manifest.metadata.name
+  description = "Service name, for DNS / ingress / Flagger traffic routing."
+}

--- a/devtools/bifrost/terraform/modules/service_kubernetes/variables.tf
+++ b/devtools/bifrost/terraform/modules/service_kubernetes/variables.tf
@@ -1,0 +1,101 @@
+variable "name" {
+  type        = string
+  description = "Workload name. Used for Deployment, Service, ServiceAccount, HPA, and the derived GSA account_id."
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace."
+}
+
+variable "project_id" {
+  type        = string
+  description = "GCP project that owns the runtime service account and Secret Manager secrets."
+}
+
+variable "image" {
+  type        = string
+  description = "Container image, digest-pinned."
+  validation {
+    condition     = can(regex("@sha256:[0-9a-f]{64}$", var.image))
+    error_message = "image must be digest-pinned: <registry>/<repo>@sha256:<64-hex>"
+  }
+}
+
+variable "port" {
+  type        = number
+  default     = 8080
+  description = "Container port exposed by the Service and probed by the container."
+}
+
+variable "args" {
+  type        = list(string)
+  default     = []
+  description = "Container args. Image entrypoint is preserved."
+}
+
+variable "resources" {
+  type        = object({ cpu = number, memory = number })
+  description = "CPU in cores (float, 0.25 = 250m). Memory in MiB (int, 512 = 512Mi). Only requests.cpu is set (no CPU limit); memory requests == limits."
+}
+
+variable "env" {
+  type        = map(string)
+  default     = {}
+  description = "Plain environment variables. Values may reference other Terraform outputs."
+}
+
+variable "secret_env" {
+  type = map(object({
+    project = string
+    secret  = string
+    version = string
+  }))
+  default     = {}
+  description = "Secret env vars sourced from GCP Secret Manager via an ephemeral block + data_wo. version must be an explicit integer; \"latest\" is rejected (immutability)."
+  validation {
+    condition     = alltrue([for k, v in var.secret_env : v.version != "latest" && can(regex("^[0-9]+$", v.version))])
+    error_message = "secret_env[*].version must be an explicit integer; \"latest\" is forbidden."
+  }
+}
+
+variable "autoscaling" {
+  type = object({
+    min                    = number
+    max                    = number
+    target_cpu_utilization = optional(number, 80)
+  })
+  description = "HPA bounds. min must be >= 1 (HPA requirement); no silent clamping."
+  validation {
+    condition     = var.autoscaling.min >= 1 && var.autoscaling.max >= var.autoscaling.min
+    error_message = "autoscaling.min must be >= 1 (HPA requirement) and autoscaling.max must be >= autoscaling.min."
+  }
+}
+
+variable "probes" {
+  type = object({
+    startup_path   = optional(string)
+    liveness_path  = optional(string)
+    readiness_path = optional(string)
+  })
+  default     = {}
+  description = "HTTP GET probe paths. Omit a field to skip that probe. readiness_path is how pods signal \"not ready for traffic right now\" — important for graceful shutdown and slow warmups."
+}
+
+variable "vpa_enabled" {
+  type        = bool
+  default     = true
+  description = "Emit a VerticalPodAutoscaler in InPlaceOrRecreate mode, scoped to memory on the \"app\" container. VPA actively resizes memory at runtime. Requires the VPA CRD to be installed in the cluster; set false if unavailable."
+}
+
+variable "service_account_id" {
+  type        = string
+  default     = null
+  description = "GSA account_id for the runtime identity. Defaults to \"svc-<name>\"."
+}
+
+variable "labels" {
+  type        = map(string)
+  default     = {}
+  description = "Labels applied to Deployment, Service, and ServiceAccount."
+}

--- a/devtools/bifrost/terraform/modules/service_kubernetes/versions.tf
+++ b/devtools/bifrost/terraform/modules/service_kubernetes/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.14.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.38"
+    }
+  }
+}

--- a/devtools/bifrost/terraform/modules/validate.sh
+++ b/devtools/bifrost/terraform/modules/validate.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Local-only: runs `terraform init -backend=false && terraform validate`.
+# Not wrapped in sh_test because init needs network to download providers
+# and the Bazel sandbox blocks it. Invoke via `bazel run`.
+set -euo pipefail
+
+TERRAFORM="$BUILD_WORKSPACE_DIRECTORY/$(realpath --relative-to="$BUILD_WORKSPACE_DIRECTORY" "$1")"
+shift
+
+MODULE_DIR="$BUILD_WORKSPACE_DIRECTORY/devtools/bifrost/terraform/modules/${TARGET_NAME:-service}"
+
+# Allow override: bazel run ... -- /path/to/module
+if [[ $# -gt 0 ]]; then
+  MODULE_DIR="$1"
+fi
+
+cd "$MODULE_DIR"
+"$TERRAFORM" init -backend=false -input=false
+"$TERRAFORM" validate


### PR DESCRIPTION
## Summary
- Introduces four reusable Terraform modules under `devtools/bifrost/terraform/modules/`: `service_cloudrun`, `service_kubernetes`, `cronjob_cloudrun`, `cronjob_kubernetes`.
- Each module ships with `main.tf`, `variables.tf`, `outputs.tf`, `versions.tf`, a README, at least one `examples/` subdir, and a Bazel `BUILD` file.
- Adds shared `fmt_check.sh` and `validate.sh` scripts at the modules root to standardize formatting and validation across all four modules.

## Test plan
- [ ] `./devtools/bifrost/terraform/modules/fmt_check.sh` passes
- [ ] `./devtools/bifrost/terraform/modules/validate.sh` passes
- [ ] `bazel build //devtools/bifrost/terraform/modules/...`
- [ ] `bazel test //devtools/bifrost/terraform/modules/...`
- [ ] Spot-check each `examples/basic/main.tf` renders a sensible `terraform plan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added four reusable Terraform modules: Cloud Run and Kubernetes services, Cloud Run cronjobs with Cloud Scheduler, and Kubernetes cronjobs with Workload Identity integration.
  * Modules support Secret Manager integration, configurable autoscaling, health probes, and security hardening via least-privilege service accounts.

* **Documentation**
  * Added comprehensive module documentation and working examples for deploying containerized applications.

* **Chores**
  * Added automated validation and linting for module configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->