### PR TITLE
ci: trigger bazel lockfile refresh on terraform provider bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -116,6 +116,23 @@
       ]
     },
     {
+      "matchManagers": [
+        "terraform",
+        "terraform-lockfile"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "bazel mod deps --lockfile_mode=update",
+          "bazel mod tidy"
+        ],
+        "fileFilters": [
+          ".terraform.lock.hcl",
+          "MODULE.bazel.lock"
+        ],
+        "executionMode": "update"
+      }
+    },
+    {
       "matchDepNames": ["rules_img", "rules_img_tool"],
       "groupName": "rules_img",
       "groupSlug": "rules_img"


### PR DESCRIPTION
Renovate's `terraform` / `terraform-lockfile` managers update `.terraform.lock.hcl` when a provider version moves, but none of the existing postUpgradeTasks matched them — so the bump PR shipped a `.terraform.lock.hcl` change without the corresponding `MODULE.bazel.lock` refresh, and CI failed at analysis time:

  ERROR: MODULE.bazel.lock is no longer up-to-date because an input to
  the extension '@@terraform.bzl+//terraform:extensions.bzl%terraform'
  changed: file info or contents of @@//.terraform.lock.hcl changed.
  Please run `bazel mod deps --lockfile_mode=update` to update your
  lockfile.

(seen on #252)

Add a packageRule matching both managers with the same `bazel mod deps --lockfile_mode=update && bazel mod tidy` postUpgrade already used for `gomod` / `npm` / etc. `fileFilters` lists both `.terraform.lock.hcl` (modified by Renovate) and `MODULE.bazel.lock` (modified by the postUpgradeTask), so the PR ships with a coherent pair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation configuration for improved handling of Terraform dependency updates and lock file management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkeros/senku/pull/258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->