### PR TITLE
ci: regenerate go.sum with hermetic go on renovate gomod updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -102,10 +102,13 @@
       ],
       "postUpgradeTasks": {
         "commands": [
+          "bazel run @rules_go//go -- mod tidy",
           "bazel mod deps --lockfile_mode=update",
           "bazel mod tidy"
         ],
         "fileFilters": [
+          "go.mod",
+          "go.sum",
           "bazel/include/go.MODULE.bazel",
           "MODULE.bazel.lock",
           "bazel/modules/*/MODULE.bazel",

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -30,4 +30,4 @@ jobs:
           LOG_LEVEL: debug
           RENOVATE_ONBOARDING: "false"
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_ALLOWED_COMMANDS: '["^\\./tools/repin$", "^bazel mod tidy$", "^bazel mod deps --lockfile_mode=update$", "^pnpm install --lockfile-only$"]'
+          RENOVATE_ALLOWED_COMMANDS: '["^\\./tools/repin$", "^bazel run @rules_go//go -- mod tidy$", "^bazel mod tidy$", "^bazel mod deps --lockfile_mode=update$", "^pnpm install --lockfile-only$"]'


### PR DESCRIPTION
## Problem

Renovate `gomod` update PRs that touch a Go `tool`-directive dependency fail the build. The clearest example is [#323](https://github.com/arkeros/senku/pull/323) (bump `github.com/yannh/kubeconform`), which errors with:

```
ERROR: loading failure: ... No sum for github.com/yannh/kubeconform@v0.8.0 found, update go.sum with:
  bazel run @rules_go//go -- mod tidy
ERROR: //bazel/toolchains/kubeconform:compiled_kubeconform_toolchain: analysis failure
```

## Root cause

`go.mod` declares `kubeconform/cmd/kubeconform` via a Go 1.24+ `tool (...)` directive, and `//bazel/toolchains/kubeconform` builds it from source through gazelle's `go_deps`. That requires the module-zip (`h1:`) hash in `go.sum`.

Renovate's native `goModTidy` produced a `go.sum` with only the `/go.mod` hash for the bumped tool dep — not the `h1:` hash — so `go_deps` can't verify/build the module. Verified locally with the bazel-pinned go (`go1.26.4`): `go mod tidy` records the missing `h1:` lines that the PR's `go.sum` lacked.

## Fix

For the `gomod` package rule:
- Run `bazel run @rules_go//go -- mod tidy` (the hermetic go SDK the build itself uses, and the exact remedy the error prints) as the first `postUpgradeTask`, before the `bazel mod` steps.
- Add `go.mod` and `go.sum` to the task `fileFilters` so the completed sums are committed to the PR.
- Allowlist the new command (exact-anchored) in `RENOVATE_ALLOWED_COMMANDS`, alongside the existing `bazel mod` steps.

Once merged, `recreateWhen: always` will let renovate recreate #323 (and future go-update PRs) with a complete `go.sum`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)