### PR TITLE
ci: detect root-level hummingbird.lock.json in rpm update gate

### DIFF
--- a/.github/actions/update-rpm-packages/action.yaml
+++ b/.github/actions/update-rpm-packages/action.yaml
@@ -34,12 +34,12 @@ runs:
           git diff --stat || true
           echo
           echo "Per-package sha256 changes (excludes repomd_sha256):"
-          git diff -- '**/*.lock.json' \
+          git diff -- '*.lock.json' \
             | grep -E '^[+-].*"sha256"' \
             | grep -v 'repomd_sha256' || true
           echo
           echo "Lockfile package/version/path changes (first 400 lines):"
-          git diff -- '**/*.lock.json' \
+          git diff -- '*.lock.json' \
             | grep -E '^[+-].*"(version|sha256|path|upstream)"' \
             | sed -n '1,400p' || true
           echo "::endgroup::"
@@ -96,7 +96,13 @@ runs:
         #
         # Avoid `grep -q` under `pipefail` — early grep exit can SIGPIPE the
         # upstream `git diff` and turn a real match into a false negative.
-        if ! git diff -- '**/*.lock.json' \
+        #
+        # Pathspec is `*.lock.json`, NOT `**/*.lock.json`: git's `**/`
+        # requires a directory prefix, so it silently skips the root-level
+        # `hummingbird.lock.json` and the gate would misread every real
+        # hummingbird binary update as metadata-only churn. `*` already
+        # crosses `/`, so this matches both the root and nested lockfiles.
+        if ! git diff -- '*.lock.json' \
              | grep -E '^[+-].*"sha256"' \
              | grep -v 'repomd_sha256' >/dev/null; then
           print_update_diff


### PR DESCRIPTION
## Problem

The Update RPM Packages workflow hasn't opened a PR since #269 (2026-05-22), despite running daily — every run reports a ~264-line `hummingbird.lock.json` diff but concludes *"Only repo-metadata revision changed, no binary package changes. Skipping."*

That conclusion is wrong. The metadata-vs-binary skip gate in `.github/actions/update-rpm-packages/action.yaml` classifies the change with:

```bash
git diff -- '**/*.lock.json' | grep '"sha256"' | grep -v 'repomd_sha256'
```

Git's `**/` pathspec requires a directory prefix, so it **never matches the root-level `hummingbird.lock.json`** — only the nested nginx RPM lockfiles:

```
$ git ls-files -- '**/*.lock.json'
oci/distroless/nginx/nginx-mainline.hummingbird.lock.json
oci/distroless/nginx/nginx-stable.hummingbird.lock.json     # hummingbird.lock.json missing
```

So every real hummingbird package update is invisible to the gate, gets misread as repo-metadata churn, is reverted with `git checkout -- .`, and skipped. The `git diff --name-only` precheck (no pathspec) still sees the file changed — that's why the workflow runs but never produces a PR. Net effect: **hummingbird (the base for the distroless images) has silently stopped receiving package/CVE updates.**

## Fix

Use `*.lock.json` instead of `**/*.lock.json` in all three `git diff` invocations. `*` crosses `/` in a git pathspec, so it matches both the root and nested lockfiles. Only the re-pinned RPM lockfiles appear in the diff, so the broader glob is safe.

### Verification

Injecting a real per-package `sha256` change into `hummingbird.lock.json`:

| pathspec | detects the change? |
|---|---|
| `'**/*.lock.json'` (old) | ❌ no → gate skips the PR |
| `'*.lock.json'` (new) | ✅ yes |

The first scheduled run after merge will surface whatever hummingbird updates have accumulated since 2026-05-22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved RPM lockfile update detection to more accurately identify package changes versus metadata-only updates in automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->