### PR TITLE
build: pin ANDROID_HOME empty for hermetic @androidsdk fetch

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -37,6 +37,14 @@ common --registry=https://bcr.bazel.build
 # alternative `--linkopt=-no-pie` workaround.
 common --@rules_go//go/config:linkmode=pie
 
+# We build no Android code, but rules_android's @androidsdk repo rule reads
+# ANDROID_HOME and hard-fails when it points at a directory without SDK APIs
+# (e.g. Renovate's containerbase image sets it to an empty ~/.android-sdk,
+# which broke every `bazel run` postUpgradeTask). Pin it empty so the repo
+# rule always takes its "empty repository that allows non-Android code to
+# build" path, regardless of host environment.
+common --repo_env=ANDROID_HOME=
+
 # Enforce ADR 0006 at analysis time: any `image_push` to the public mirror
 # surface (`ghcr.io/arkeros/senku/*`) without the `mirror_push_managed` tag
 # fails the build. Wired here (not as a `--config=`) so the policy is


### PR DESCRIPTION
## Why

Every `bazel run`-based Renovate `postUpgradeTask` currently crashes inside the Renovate container (13 failures in run 29106445623 alone). Root cause: rules_android's `android_sdk_repository` hard-fails when `ANDROID_HOME` points at a directory without SDK APIs, and the containerbase image sets `ANDROID_HOME=~/.android-sdk` (SDK-less):

```
ERROR: .../rules_android+/rules/android_sdk_repository/rule.bzl:114:13: ...
Error in fail: No Android SDK apis found in the Android SDK at /home/ubuntu/.android-sdk.
```

Because of this, `tools/repin` dies before reaching `bazel run //python:gazelle_python_manifest.update`, so Python update PRs land with a stale `gazelle_python.yaml` and fail `//python:gazelle_python_manifest.test` with an integrity-hash mismatch — that's what is blocking #385 (renovate/absl-py-2.x).

## What

One line in `.bazelrc`:

```
common --repo_env=ANDROID_HOME=
```

We build no Android code. An empty `ANDROID_HOME` is falsy in the repo rule (`if not android_sdk_path:`), so it always takes its "empty repository that allows non-Android code to build" path — on the Renovate container, CI, and dev machines alike. This also removes a host non-hermeticity: a developer with a real Android SDK installed previously got a different `@androidsdk` repo than everyone else.

## Verification (red/green)

With `ANDROID_HOME` pointed at an empty directory:

- without this flag: `bazel fetch --repo=@@rules_android++android_sdk_repository_extension+androidsdk` fails with the exact error above
- with this flag: `INFO: All requested repos fetched successfully.`

After this merges, Renovate's next run on #385 should rerun `./tools/repin` successfully and commit the regenerated `gazelle_python.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build reliability for non-Android components across environments where Android SDK configuration may be incomplete or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->